### PR TITLE
carton exec should use exec

### DIFF
--- a/bin/carton
+++ b/bin/carton
@@ -14,7 +14,7 @@ else
   elif [[ $1 == "install" ]]; then
     COMMAND=install
   elif [[ $1 == "exec" ]]; then
-    EMACSLOADPATH=$($EMACS -Q --batch --eval '(message (mapconcat (quote identity) (append (file-expand-wildcards "elpa/*" t) load-path) ":"))' 2>&1) ${@:2}
+    EMACSLOADPATH=$($EMACS -Q --batch --eval '(message (mapconcat (quote identity) (append (file-expand-wildcards "elpa/*" t) load-path) ":"))' 2>&1) exec ${@:2}
   else
     echo "Could not find task '$1'."
     echo "usage: carton [INSTALL]"


### PR DESCRIPTION
My primary usage of Carton is for testing.  That's why exit code is important.  Please use `exec` as in my PR, or use exit to set appropriate error code.
