### PR TITLE
Properly quote arguments for exec

### DIFF
--- a/bin/carton
+++ b/bin/carton
@@ -16,7 +16,7 @@ else
   elif [[ $1 == "update" ]]; then
     COMMAND=update
   elif [[ $1 == "exec" ]]; then
-    EMACSLOADPATH=$($EMACS -Q --batch --eval '(message (mapconcat (quote identity) (append (file-expand-wildcards "elpa/*" t) load-path) ":"))' 2>&1) exec ${@:2}
+    EMACSLOADPATH=$($EMACS -Q --batch --eval '(message (mapconcat (quote identity) (append (file-expand-wildcards "elpa/*" t) load-path) ":"))' 2>&1) exec "${@:2}"
   else
     echo "Could not find task '$1'."
     echo "usage: carton [INSTALL]"


### PR DESCRIPTION
Just wrap `${@:2}` with double quotes.
