### PR TITLE
Fix go script

### DIFF
--- a/go
+++ b/go
@@ -7,7 +7,7 @@ if [ -d "$CARTON_DIR" ]; then
 
   exit 1
 else
-  git clone https://github.com/rejeep/carton.git $CARTON_DIR &> /dev/null
+  git clone https://github.com/rejeep/carton.git $CARTON_DIR 2> /dev/null
 
   echo "Successfully installed Carton! Now, add the carton binary to your PATH."
   echo '  export PATH="'${CARTON_DIR}'/bin:$PATH"'


### PR DESCRIPTION
Currently the install script is not working as intended.  This is a log from my Travis CI build:

```
27 $ curl -fsSkL --max-time 10 --retry 10 --retry-delay 10 https://raw.github.com/rejeep/carton/master/go | sh
28 sh: 5: [[: not found
29 Successfully installed Carton! Now, add the carton binary to your PATH.
30   export PATH="/home/travis/.carton/bin:$PATH"
31
32 Cloning into '/home/travis/.carton'...
```

see, e.g., https://travis-ci.org/tkf/emacs-jedi/jobs/3126875/#L27

Line 28 means there is some failure in the script and line 32 says git clone is not finished even if the shell exits go script.  The former error is fixed by d9771f20a6e37879927e55643610f68f4bcbdd10 and the second is fixed by 0dc94caafb0194d11b3cd7d86015873551b7c3cd.

Alternative to the fix d9771f20a6e37879927e55643610f68f4bcbdd10 is to change the instruction in README to

``` sh
curl -fsSkL https://raw.github.com/rejeep/carton/master/go | bash
```

Regarding 0dc94caafb0194d11b3cd7d86015873551b7c3cd, I am not sure what you wanted to do by `&> /dev/null`.  I assumed you wanted less less verbose output, so I suppressed stderr.
