### PR TITLE
carton bash script modifications

### DIFF
--- a/bin/carton
+++ b/bin/carton
@@ -5,7 +5,7 @@ if [ -z "$EMACS" ] || [ -z "`which $EMACS`" ] ; then
 fi
 
 if [ -z "$CARTON_DIR" -o ! -d "$CARTON_DIR" ] ; then
-  $CARTON_DIR=$(dirname $(dirname $BASH_SOURCE))
+  CARTON_DIR=$(dirname $(dirname $BASH_SOURCE))
 fi
  
 CARTON_EL=$CARTON_DIR/carton.el


### PR DESCRIPTION
I'm running Emacs 24.2.1 from Homebrew on Mac OS X 10.8.2.  I am running carton from an ansi-term inside Emacs, in which case it sets to the `$EMACS` environment variable to `"24.2.1 '(term:0.96)'"`, which broke the script.  I added a check for whether the setting of that variable is a valid command.

Also in my setup I wanted to mirror my other homebrew installs by installing carton under `/usr/local/Cellar` and then symlinking `bin/carton` into `/usr/local/bin`.  This breaks the current logic for finding carton.el, so I added a check for a `$CARTON_DIR` environment variable for the cases in which people might want to do that.
