### PR TITLE
Fix shebang

### DIFF
--- a/bin/carton
+++ b/bin/carton
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$EMACS" ] || [ -z "`which $EMACS`" ] ; then
   EMACS=emacs

--- a/go
+++ b/go
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 CARTON_DIR="$HOME/.carton"
 


### PR DESCRIPTION
- bin/carton
  bash is not installed at /bin on some platform, such as FreeBSD(Usually
  bash is installed at /usr/local/bin). So using 'env' command is better
  than using '/bin/bash' directly.
- go
  In README.md, this shell script is executed by sh(not bash)

Please see the patch.
