### PR TITLE
Improve updates

### DIFF
--- a/carton.el
+++ b/carton.el
@@ -116,7 +116,13 @@
     (mapc
      (lambda (package)
        (package-install (car package)))
-     (package-menu--find-upgrades))))
+     (package-menu--find-upgrades))
+    ;; Delete obsolete packages
+    (mapc
+     (lambda (package)
+       (package-delete (symbol-name (car package))
+                       (package-version-join (caadr package))))
+     package-obsolete-alist)))
 
 (defun carton-package ()
   "Package this project."


### PR DESCRIPTION
These change sets fix and improve package updates in `carton update`.

Arguments to `package-menu--generate` are fixed to include all packages, and obsolete packages are deleted after updates.
