### PR TITLE
Add command to print package version

### DIFF
--- a/bin/carton
+++ b/bin/carton
@@ -22,6 +22,8 @@ if [[ $# -eq 0 ]]; then
 else
   if [[ $1 == "package" ]]; then
     COMMAND=package
+  elif [[ $1 == "version" ]]; then
+    COMMAND=version
   elif [[ $1 == "install" ]]; then
     COMMAND=install
   elif [[ $1 == "update" ]]; then

--- a/carton.el
+++ b/carton.el
@@ -124,6 +124,10 @@
                        (package-version-join (caadr package))))
      package-obsolete-alist)))
 
+(defun carton-version ()
+  "Print the version of this project."
+  (princ (format "%s\n" (carton-package-version carton-package))))
+
 (defun carton-package ()
   "Package this project."
   (let ((content (carton-define-package-string)))

--- a/templates/usage.tpl
+++ b/templates/usage.tpl
@@ -6,6 +6,7 @@ COMMANDS:
  update                 Update dependencies
  exec                   Execute command with correct dependencies
  init                   Create basic Carton file
+ version                Show the package version
 
 OPTIONS:
  -h, --help             Display this help message


### PR DESCRIPTION
Add a `version` command to print the version of the package:

```
$ cat Carton
(source "melpa" "http://melpa.milkbox.net/packages/")

(package "flycheck" "0.6.1" "Flymake done right

Flycheck provides on-the-fly syntax checker with

- major-mode based checkers,
- simple declarative checker definitions,
- built-in checkers for many languages,
- standard error navigation,
- easy customization,
- and a clean, concise and understandable implementation.")

(depends-on "s" "1.3.1")
(depends-on "dash" "1.0.3")

;; Various modes for use in the unit tests
(development
 (depends-on "coffee-mode")
 (depends-on "haml-mode")
 (depends-on "js2-mode")
 (depends-on "js3-mode")
 (depends-on "lua-mode")
 (depends-on "cperl-mode")
 (depends-on "php-mode")
 (depends-on "php+-mode")
 (depends-on "sass-mode"))
$ carton version
0.6.1
```

This command is intended to easy the writing of Makefiles or other build scripts that may need the package version.

See the [Flycheck `Makefile`](https://github.com/lunaryorn/flycheck/blob/info-manual/Makefile) for an example for this command.
