### PR TITLE
Support for headers in package files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ To automatically install Carton, run this command:
 You can also clone the repository.
 
     $ git clone https://github.com/rejeep/carton.git
-    
+
 Don't forget to add Carton's bin to your `PATH`.
-    
+
     $ export PATH="/path/to/code/carton/bin:$PATH"
-    
+
 
 ## Usage
 
@@ -98,6 +98,18 @@ Add a runtime dependency.
 Example:
 
     (depends-on "magit" "0.8.1")
+
+### package-file
+
+Define this package and its runtime dependencies from the package headers of a
+file (used only for package development).  The name of the file is relative to
+the directory containing the `Carton` file.
+
+    (package-file FILENAME)
+
+Example:
+
+    (package-file "foo.el")
 
 ### development
 

--- a/test/carton-test.el
+++ b/test/carton-test.el
@@ -38,6 +38,23 @@
     (should (equal (carton-package-version carton-package) "0.0.1"))
     (should (equal (carton-package-description carton-package) "Foo."))))
 
+(ert-deftest test-carton-package-file ()
+  "Should define package file."
+  (let ((carton-project-path carton-test-path)
+        carton-package
+        carton-runtime-dependencies carton-development-dependencies)
+    (carton-eval '((package-file "sample-package.el")))
+    (should (equal (carton-package-name carton-package) "sample-package"))
+    (should (equal (carton-package-version carton-package) "1.0beta1"))
+    (should (equal (carton-package-description carton-package)
+                   "Sample package for tests"))
+    (let ((package (nth 0 carton-runtime-dependencies)))
+      (should (equal (carton-dependency-name package) 'foo))
+      (should (equal (carton-dependency-version package) "1.0")))
+    (let ((package (nth 1 carton-runtime-dependencies)))
+      (should (equal (carton-dependency-name package) 'bar))
+      (should (equal (carton-dependency-version package) "1.1beta3")))))
+
 (ert-deftest test-depends-on-runtime ()
   "Should add as runtime dependency."
   (let (carton-runtime-dependencies carton-development-dependencies)

--- a/test/sample-package.el
+++ b/test/sample-package.el
@@ -1,0 +1,42 @@
+;;; sample-package.el --- Sample package for tests
+
+;; Copyright (C) 2012, 2013 Johan Andersson
+;; Copyright (C) 2013 Sebastian Wiesner
+
+;; Author: Johan Andersson <johan.rejeep@gmail.com>
+;; Maintainer: Johan Andersson <johan.rejeep@gmail.com>
+;; Version: 1.0beta1
+;; Keywords: examples
+;; Package-Requires: ((foo "1.0") (bar "1.1beta3"))
+;; URL: http://github.com/rejeep/carton
+
+;; This file is NOT part of GNU Emacs.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+;; Copyright (C) 2010-2013 Your Name
+
+;; Author: Your Name <yourname@example.com>
+;; Maintainer: Someone Else <someone@example.com>
+;; Created: 14 Jul 2010
+;; Keywords: foo
+
+;;; Code:
+
+(provide 'sample-package)
+
+;;; sample-package.el ends here


### PR DESCRIPTION
Currently carton insists that dependencies are specified in the `Carton` file.  It does not support the standard `Package-Requires` header, nor does it read existing `-pkg.el` files.

MELPA however does not read Carton files, but insists on either `Package-Requires` or a `-pkg.el` file in the source tree.

To use Carton as a package author, while still deploying to MELPA, I can now either
- commit the `-pkg.el` file generated by Carton,
- or duplicate dependency information between `Carton` and the `Package-Requires` of `foo.el`.

Neither of these is particularly nice.

To cleanly work together with MELPA, either
- MELPA should support for Carton,
- or Carton should support the standard package headers.

The former is quite unlikely given that Carton is a non-standard approach, and that one of the MELPA devs [explicitly expressed his concerns about Carton support in MELPA](https://twitter.com/sanityinc/status/321573924490051584).

So ideally Carton would get support for standard package headers.

I'd propose the addition of a new directive `(package-file "foo.el)` which extracts package information from the `foo.el` file, following the [library header conventions](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html#Library-Headers), and thus works as a complete replacement for all top-level `package` and `depends-on` directives.

Precisely, with this directive Carton would
- extract the package name from the file name in the first line,
- extract the package description form the first line,
- read the package version from the `Package-Version` header if present, or the `Version` header,
- read the runtime dependencies from the `Package-Requires` header.

The package archives would still be read from the `source` directive, as would all development dependencies from the `development` directive.

Thus, an example `Carton` following this scheme would look like:

``` scheme
(source "melpa" "http://melpa.milkbox.net/packages/")

(package-file "foo.el")

(development
    (depends-on "ecukes"))
```
