### PR TITLE
Some cleanup

### DIFF
--- a/bin/carton
+++ b/bin/carton
@@ -25,8 +25,10 @@ else
 fi
 
 case "$COMMAND" in
-  package|version|install|update|list|info)
-    "$EMACS" --batch --load "$CARTON_EL" --eval "(progn (carton-setup \"${PWD}\") (carton-${COMMAND}))"
+    package|version|install|update|list|info)
+    export CARTON_PROJECT_PATH="$PWD"
+    export CARTON_COMMAND="$COMMAND"
+    "$EMACS" --batch --load "$CARTON_EL" --funcall carton-handle-commandline
     ;;
   init)
     cat "$TEMPLATE_DIR/init.tpl" > Carton


### PR DESCRIPTION
- Use `case` to simplify command parsing in `bin/carton`
- Properly quote all variables in `bin/carton`
- Use environment variables to pass command and project path from
  `bin/carton` to `carton.el` to deal with the (admittedly unlikely)
  case that someone has a quotation mark in his directory name.  This
  also shortens the corresponding part of `bin/carton`, making it easier
  to read.  Also, the less bash script, the better ;)

I originally did this because I wanted to add a new `sync` command that would remove packages, that were removed from `Carton`, and install packages added to it.

However, I got stuck on this, because there is no way to tell why an installed package is not in `Carton`.  It may have been removed, but it may just as well only be a dependency of a package in `Carton`.

Instead, I am now thinking about a `reinstall` command that removes all installed packages, and re-installs them.  It's mainly intended for the `~/.emacs.d` use case, to keep your packages in sync with what is contained in `Carton`, especially when syncing `~/.emacs.d` across multiple systems.

Would you be interested in this?
