### PR TITLE
Resolve symlinks properly

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -3,5 +3,15 @@
 if [[ "$1" == "exec" ]]; then
   EMACSLOADPATH="$($0 load-path)" PATH="$($0 path)" exec "${@:2}"
 else
-  exec "${EMACS:-emacs}" --script "$(dirname $(dirname $0))/cask-cli.el" -- "$@"
+  # Find the Cask installation directory by resolving the symlink chain to the
+  # current executable.  We don't use "readlink -f" or "realpath", because these
+  # utilities are missing on OS X.  Instead we rely on Emacs doing this work for
+  # us.  Unfortunately we can't give the script path as command line argument
+  # directly, because that makes Emacs visit the file, printing all sorts of
+  # messages and spoiling our output.  Hence We use an environment variable to
+  # pass the script path to the Emacs process.
+  CASK_PATH="$(__CASK_SCRIPT="$0" "${EMACS:-emacs}" -Q --batch --eval '(princ (file-truename (getenv "__CASK_SCRIPT")))')"
+  CASK_DIR="$(dirname "$(dirname "${CASK_PATH}")")"
+
+  exec "${EMACS:-emacs}" --script "${CASK_DIR}/cask-cli.el" -- "$@"
 fi


### PR DESCRIPTION
When determining the Cask directory we have to resolve the chain of symlinks pointing to the executable, in case someone linked jsut the `cask` binary somewhere into `$PATH`.

We did this in 0.3, with quite similar code, but it seems to have been lost in the rewriting of Carton in plain Emacs Lisp (looking at your, @rejeep ;) ).  This PR brings the old behavior back.

After merging this branch, we should push a 0.4.1 release immediately, because it's a showstopper on Travis CI (at least for my projects).
