### PR TITLE
Include all commander dependencies in bootstrap.

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -21,7 +21,7 @@
   (cask-resource-path (format ".cask/%s/bootstrap" emacs-version))
   "Path to Cask ELPA dir.")
 
-(defconst cask-bootstrap-packages '(commander s dash cl-lib)
+(defconst cask-bootstrap-packages '(commander)
   "List of bootstrap packages required by this file.")
 
 (unwind-protect


### PR DESCRIPTION
@lunaryorn I remember you mentioned this at some point, but it was forgotten. Example when it fails: https://travis-ci.org/rejeep/ecukes/jobs/9912914
