### PR TITLE
Bootstrap in a user-writable directory

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -18,8 +18,9 @@
 
 ;; Bootstrap the dependencies of the CLI wrapper
 (defconst cask-bootstrap-dir
-  (cask-resource-path (format ".cask/%s/bootstrap" emacs-version))
-  "Path to Cask ELPA dir.")
+  (expand-file-name
+   (locate-user-emacs-file (format ".cask/%s/bootstrap" emacs-version)))
+  "Path to Cask bootstrap directory.")
 
 (defconst cask-bootstrap-packages '(commander)
   "List of bootstrap packages required by this file.")


### PR DESCRIPTION
Follow up of #74.  This change moves the bootstrap directory to XDG data home.  It's dead simple, and won't break anything.  Ecukes tests pass as expected.  It will cause Cask to bootstrap anew, but I can't think of any trouble this might cause.

I'd like to merge this, because bootstrapping at installation as suggested in #74 turns out to be more complicated than I initially thought.  I doubt whether it's actually possible, but even if, it will require a good deal of thought and care, hence much time.  

To fix root installations meanwhile, we should move the bootstrap directory now and publish a new release.  We can still implement bootstrapping at installation later on.
