### PR TITLE
Bootstrap packages added to load path

### DIFF
--- a/epl-legacy.el
+++ b/epl-legacy.el
@@ -100,6 +100,8 @@ Parse the package metadata of BUFFER and return a corresponding
 
 ;;;; Package system management
 
+(defvar epl--load-path-before-initialize)
+
 (defun epl-reset ()
   "Reset the package system.
 
@@ -108,7 +110,8 @@ package archives and reset the package directory."
   (setq package-alist nil
         package-obsolete-alist nil
         package-archives nil
-        package-archive-contents nil)
+        package-archive-contents nil
+        load-path epl--load-path-before-initialize)
   (epl-change-package-dir (epl-default-package-dir)))
 
 

--- a/epl-package-desc.el
+++ b/epl-package-desc.el
@@ -97,6 +97,8 @@ Parse the package metadata of BUFFER and return a corresponding
 
 ;;;; Package system management
 
+(defvar epl--load-path-before-initialize)
+
 (defun epl-reset ()
   "Reset the package system.
 
@@ -104,7 +106,8 @@ Clear the list of installed and available packages, the list of
 package archives and reset the package directory."
   (setq package-alist nil
         package-archives nil
-        package-archive-contents nil)
+        package-archive-contents nil
+        load-path epl--load-path-before-initialize)
   (epl-change-package-dir (epl-default-package-dir)))
 
 

--- a/epl.el
+++ b/epl.el
@@ -177,7 +177,15 @@ Return an `epl-package' object with the header metadata."
 
 ;;;; Package system management
 
-(defalias 'epl-initialize 'package-initialize)
+(defvar epl--load-path-before-initialize nil
+  "Remember the load path for `epl-reset'.")
+
+(defun epl-initialize (&optional no-activate)
+  "Load Emacs Lisp packages and activate them.
+
+With NO-ACTIVATE non-nil, do not activate packages."
+  (setq epl--load-path-before-initialize load-path)
+  (package-initialize no-activate))
 
 (defalias 'epl-refresh 'package-refresh-contents)
 


### PR DESCRIPTION
This line https://github.com/rejeep/cask.el/blob/master/cask-cli.el#L31 will add the bootstrap packages to `load-path`.

To reproduce:

``` bash
$ mkdir foo
$ cd foo
$ cask load-path
/Users/rejeep/.emacs.d/.cask/24.3.1/bootstrap/commander-20130812.2237:/Users/rejeep/.emacs.d/.cask/24.3.1/bootstrap/f-20130729.1445...
```

@lunaryorn You know this best. I guess this is expected behavior for `epl-initialize`, so maybe we should wrap the `unwind-protect` with something like this:

``` lisp
(let ((load-path (copy-seq load-path)))
  (unwind-protect
      ...
    ))
```
