### PR TITLE
Add gnu as source.

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,3 +1,4 @@
+(source gnu)
 (source melpa)
 
 (package-file "cask.el")


### PR DESCRIPTION
Emacs-23 needs this because some dependency to Cask requires cl-lib,
which is only available in the gnu elpa source.
