### PR TITLE
Output a new line after printing version.

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -128,7 +128,7 @@
 
 (defun cask-cli/version ()
   (cask-cli--setup)
-  (princ (cask-version)))
+  (princ (concat (cask-version) "\n")))
 
 (defun cask-cli/info ()
   (cask-cli--setup)


### PR DESCRIPTION
cask version did not print a new line after printing the version, which
made it a bit ugly when used in a terminal.
