### PR TITLE
Output a new line after printing version.

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -139,13 +139,13 @@
   (commander-print-usage-and-exit))
 
 (defun cask-cli/load-path ()
-  (princ (cask-load-path)))
+  (princ (concat (cask-load-path) "\n")))
 
 (defun cask-cli/path ()
-  (princ (cask-path)))
+  (princ (concat (cask-path) "\n")))
 
 (defun cask-cli/package-directory ()
-  (princ (cask-elpa-dir)))
+  (princ (concat (cask-elpa-dir) "\n")))
 
 (defun cask-cli/dev ()
   (setq cask-cli--dev-mode t))


### PR DESCRIPTION
cask version did not print a new line after printing the version, which
made it a bit ugly when used in a terminal.

Applied feedback given at #113.
