### PR TITLE
Use universal_newlines for Python 3 compatibility.

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -43,7 +43,8 @@ CASK_DIRECTORY = os.path.dirname(CASK_BIN_DIRECTORY)
 
 
 def get_cask_path(path):
-    process = subprocess.Popen([CASK, path], stdout=subprocess.PIPE)
+    process = subprocess.Popen([CASK, path], stdout=subprocess.PIPE,
+                               universal_newlines=True)
     stdout, _ = process.communicate()
     return stdout.rstrip()
 


### PR DESCRIPTION
The call to subprocess.Popen in get_cask_path returns a byte string
from the subprocess, which is not valid as a value in os.environ.
Passing universal_newlines=True sets the encoding of the process
to the user's default locale, which should do the right thing.
