### PR TITLE
Path option

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -46,6 +46,9 @@
 (defvar cask-cli--dev-mode nil
   "If Cask should run in dev mode or not.")
 
+(defvar cask-cli--path default-directory
+  "Cask commands will execute in this path.")
+
 (defun cask-cli--find-unbalanced-parenthesis ()
   (with-temp-buffer
     (insert (f-read-text cask-file 'utf-8))
@@ -80,7 +83,7 @@
 
 (defun cask-cli--setup ()
   (condition-case err
-      (cask-setup default-directory)
+      (cask-setup cask-cli--path)
     (end-of-file
      (cask-cli--exit-error err))
     (invalid-read-syntax
@@ -142,7 +145,7 @@
     (-each upgrades 'cask-cli--print-upgrade)))
 
 (defun cask-cli/init ()
-  (cask-new-project default-directory cask-cli--dev-mode))
+  (cask-new-project cask-cli--path cask-cli--dev-mode))
 
 (defun cask-cli/list ()
   (cask-cli--setup)
@@ -194,6 +197,9 @@
     (princ "Outdated packages:\n")
     (-each outdated 'cask-cli--print-upgrade)))
 
+(defun cask-cli/set-path (path)
+  (setq cask-cli--path path))
+
 (commander
  (name "cask")
  (description "Emacs dependency management made easy")
@@ -217,7 +223,8 @@
 
  (option "-h, --help" "Display this help message" cask-cli/help)
  (option "--dev" "Run in dev mode" cask-cli/dev)
- (option "--debug" "Turn on debug output" cask-cli/debug))
+ (option "--debug" "Turn on debug output" cask-cli/debug)
+ (option "--path <path>" "Run command in this path" cask-cli/set-path))
 
 (provide 'cask-cli)
 

--- a/features/cask.feature
+++ b/features/cask.feature
@@ -1,0 +1,25 @@
+Feature: Cask
+
+  Scenario: Change default directory
+    Given I create a project called "foo"
+    And I go to the project called "foo"
+    Given this Cask file:
+      """
+      (source "localhost" "http://127.0.0.1:9191/packages/")
+
+      (depends-on "foo" "0.0.1")
+      """
+    Given I create a project called "bar"
+    And I go to the project called "bar"
+    Given this Cask file:
+      """
+      (source "localhost" "http://127.0.0.1:9191/packages/")
+
+      (depends-on "bar" "0.0.2")
+      """
+    When I run cask "install --path {{PROJECTS-PATH}}/foo"
+    And I run cask "install --path {{PROJECTS-PATH}}/bar"
+    When I go to the project called "foo"
+    Then there should exist a package directory called "foo-0.0.1"
+    When I go to the project called "bar"
+    Then there should exist a package directory called "bar-0.0.2"

--- a/features/step-definitions/cask-steps.el
+++ b/features/step-definitions/cask-steps.el
@@ -36,6 +36,7 @@
 (defun cask-test/template (command)
   (let* ((command (s-replace "{{EMACS-VERSION}}" emacs-version command))
          (command (s-replace "{{EMACS}}" (getenv "EMACS") command))
+         (command (s-replace "{{PROJECTS-PATH}}" cask-projects-path command))
          (command (s-replace "{{PROJECT-PATH}}" cask-current-project command)))
     command))
 


### PR DESCRIPTION
Added a `--path` option. The reason is that I want to run:

``` sh
$ cask install --path /path/to
```

Instead of:

``` sh
  $ cd /path/to && cask install && cd -
```
