### PR TITLE
Ignore value of EMACS if INSIDE_EMACS is set

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -103,10 +103,10 @@ def find_best_emacs():
 
 def get_cask_emacs():
     emacs = ENVB.get(b'EMACS')
-    if b'INSIDE_EMACS' in ENVB and emacs == b't':
+    if b'INSIDE_EMACS' in ENVB:
         # If $INSIDE_EMACS is set, Cask is called from within Emacs, e.g. M-x
-        # compile.  In this case, $EMACS may be set as well to the rather
-        # meaningless value of "t".  If this is the case, we just ignore the
+        # compile.  In this case, $EMACS may be set as well to a rather
+        # meaningless value.  If $INSIDE_EMACS is set, we just ignore the
         # value of $EMACS.
         emacs = None
     emacs = emacs or find_best_emacs()


### PR DESCRIPTION
Ignore value of EMACS, regardless of its value, if INSIDE_EMACS is set.

According to the Emacs manual, EMACS should be set to "t" if
INSIDE_EMACS is set:

  36.2 Interactive Subshell

  Emacs sets the environment variable `INSIDE_EMACS' in the subshell to
`VERSION,comint', where VERSION is the Emacs version (e.g., `24.1').
  Programs can check this variable to determine whether they are running
  inside an Emacs subshell. (It also sets the`EMACS' environment
  variable to `t', if that environment variable is not already defined.
  However, this environment variable is deprecated; programs that use it
  should switch to using`INSIDE_EMACS' instead.)

However, EMACS is set to a string containing the Emacs version in
24.3.50.1:

$ env | grep EMACS
EMACS=24.3.1 (term:0.96)
INSIDE_EMACS=24.3.1,term:0.96

Instead of relying on a known value of EMACS when INSIDE_EMACS is set,
just ignore the value of EMACS.
