### PR TITLE
workaround Windows lack of shebang support

### DIFF
--- a/bin/cask.bat
+++ b/bin/cask.bat
@@ -1,0 +1,6 @@
+@ECHO OFF
+IF NOT "%~f0" == "~f0" GOTO :WinNT
+ECHO.This version of Python has not been built with support for Windows 95/98/Me.
+GOTO :EOF
+:WinNT
+@python "%~dpn0" %*

--- a/go
+++ b/go
@@ -58,8 +58,9 @@ def fail(s):
 
 def bootstrap_cask(target_directory):
     cask = os.path.join(target_directory, 'bin', 'cask')
+
     try:
-        check_call([cask, 'upgrade'])
+        check_call(["python", cask, 'upgrade'])
     except CalledProcessError:
         raise CaskGoError('Cask could not be bootstrapped. Try again later, '
                           'or report an issue at {0}'.format(ISSUE_TRACKER))

--- a/go
+++ b/go
@@ -60,7 +60,7 @@ def bootstrap_cask(target_directory):
     cask = os.path.join(target_directory, 'bin', 'cask')
 
     try:
-        check_call(["python", cask, 'upgrade'])
+        check_call([sys.executable, cask, 'upgrade'])
     except CalledProcessError:
         raise CaskGoError('Cask could not be bootstrapped. Try again later, '
                           'or report an issue at {0}'.format(ISSUE_TRACKER))


### PR DESCRIPTION
By explicitly calling `python .../<script>` instead of `<script>`, we can work around Windows' lack of shebang support. This helps with https://github.com/cask/cask/issues/198, resulting in a new error message! :)

```
Cloning into 'C:\Users\andrew\.cask'...
remote: Reusing existing pack: 2919, done.
Receiving objects: 100% (2919/2919), 793.23 KiB | 0 bytes/s, done.
remote: Total 2919 (delta 0), reused 0 (delta 0)
Resolving deltas: 100% (1630/1630), done.
Checking connectivity... done
Traceback (most recent call last):
  File "C:\Users\andrew\.cask\bin\cask", line 301, in <module>
    main()
  File "C:\Users\andrew\.cask\bin\cask", line 291, in main
    exec_cask(sys.argv[1:])
  File "C:\Users\andrew\.cask\bin\cask", line 253, in exec_cask
    emacs = get_cask_emacs()
  File "C:\Users\andrew\.cask\bin\cask", line 220, in get_cask_emacs
    ensure_supported_emacs(emacs)
  File "C:\Users\andrew\.cask\bin\cask", line 177, in ensure_supported_emacs
    if not is_supported_emacs(emacs):
  File "C:\Users\andrew\.cask\bin\cask", line 162, in is_supported_emacs
    return get_emacs_version(emacs) >= MIN_EMACS_VERSION
  File "C:\Users\andrew\.cask\bin\cask", line 146, in get_emacs_version
    raise ValueError('Could not determine the version of {0}'.format(emacs))
ValueError: Could not determine the version of emacs
Cask could not be bootstrapped. Try again later, or report an issue at https://g
ithub.com/cask/cask/issues
```
