### PR TITLE
Fix typo on stop server command in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
 after_failure:
   - cat test/servant/tmp/servant.log
 after_script:
-  - make stop-sever
+  - make stop-server


### PR DESCRIPTION
Hello, by reading your configuration, I saw a typo in .travis.yml.

By the way, thanks for cask, it greatly helps to maintain packages.

Cheers,
