### PR TITLE
Fix for encoding issue

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -179,8 +179,7 @@ def get_emacs_version(emacs):
         else:
             raise EmacsCommandError(cmd, error)
     else:
-        version = VERSION_RE.search(stdout.decode(
-            locale.getpreferredencoding()))
+        version = VERSION_RE.search(stdout)
         if not version:
             raise ValueError(
                 'Could not determine the version of Emacs at {0}'.format(emacs))


### PR DESCRIPTION
Decoding by locale.getpreferredencoding is not necessary if `universal_newlines` is True.

I got following error with latest `carton` with Python3.

```
Traceback (most recent call last):
  File "/home/syohei/.cask/bin/cask", line 348, in <module>
    main()
  File "/home/syohei/.cask/bin/cask", line 331, in main
    exec_cask(sys.argv[1:])
  File "/home/syohei/.cask/bin/cask", line 293, in exec_cask
    emacs = get_cask_emacs()
  File "/home/syohei/.cask/bin/cask", line 260, in get_cask_emacs
    ensure_supported_emacs(emacs)
  File "/home/syohei/.cask/bin/cask", line 217, in ensure_supported_emacs
    if not is_supported_emacs(emacs):
  File "/home/syohei/.cask/bin/cask", line 202, in is_supported_emacs
    return get_emacs_version(emacs) >= MIN_EMACS_VERSION
  File "/home/syohei/.cask/bin/cask", line 182, in get_emacs_version
    version = VERSION_RE.search(stdout.decode(
AttributeError: 'str' object has no attribute 'decode'
```

`subprocess` module document says 

```
If universal_newlines is True, these file objects will be opened as text streams
in universal newlines mode using the encoding returned by locale.getpreferredencoding(False).
```

https://docs.python.org/3/library/subprocess.html
