### PR TITLE
make zsh completion autoloadable

### DIFF
--- a/etc/_cask
+++ b/etc/_cask
@@ -1,3 +1,5 @@
+#compdef cask
+
 function _cask_commands() {
     local ret=1 state
     _arguments \
@@ -35,4 +37,4 @@ function _cask_commands() {
     return ret
 }
 
-compdef _cask_commands cask
+_cask_commands "$@"


### PR DESCRIPTION
This is the standard way to add completions to zsh. For the completions to be autoloaded, the file _cask must be in the $fpath of zsh, typically /usr/share/zsh/site-functions.

To add the zsh completions manually, the cask/etc directory should be added to $fpath in .zshrc, instead of sourcing the file, like it was documented in the README about a year ago.

From what I understand, this would also make it possible to autoload the autocompletion when installing from homebrew.
