### PR TITLE
Fix failing upgrade message

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -109,13 +109,13 @@
         (error "Package initialization failed: %s\nOutput:\n%s"
                message output)))
      (cask-failed-installation
-      (let* ((data (cdr err))
-             (dependency (cask-dependency-name (nth 0 data)))
-             (message (error-message-string (nth 1 data)))
-             (output (nth 2 data)))
-        (if dependency
-            (error "Dependency %s failed to install: %s\nOutput:\n%s"
-                   dependency message output)
+      (let ((data (cdr err)))
+        (if (nth 0 data)
+            (let ((name (cask-dependency-name (nth 0 data)))
+                  (message (error-message-string (nth 1 data)))
+                  (output (nth 2 data)))
+              (error "Dependency %s failed to install: %s\nOutput:\n%s"
+                     dependency message output))
           (error "Package installation failed: %s\nOutput:\n%s"
                  message output))))))
 

--- a/cask.el
+++ b/cask.el
@@ -568,7 +568,7 @@ Return list of updated packages."
               (cask--install-dependency bundle it)))
         (error
          (signal 'cask-failed-installation
-                 (list (car err) err (shut-up-current-output))))))))
+                 (list nil err (shut-up-current-output))))))))
 
 (defun cask-outdated (bundle)
   "Return list of `epl-upgrade' objects for outdated BUNDLE dependencies."


### PR DESCRIPTION
If an upgrade fails, there is no dependency to print the name of.  Just
print the error message in such case.
