### PR TITLE
Add --load-path option

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -343,6 +343,10 @@ Commands:
   "Be verbose and do not hide output."
   (setq shut-up-ignore t))
 
+(defun cask-cli/add-load-path (path)
+  "Add PATH to `load-path' before running command."
+  (add-to-list 'load-path (f-expand path)))
+
 
 ;;;; Commander schedule
 
@@ -384,7 +388,8 @@ Commands:
  (option "--dev" cask-cli/dev)
  (option "--debug" cask-cli/debug)
  (option "--path <path>" cask-cli/set-path)
- (option "--verbose" cask-cli/verbose))
+ (option "--verbose" cask-cli/verbose)
+ (option "--load-path <path>" cask-cli/add-load-path))
 
 (provide 'cask-cli)
 

--- a/doc/guide/usage.rst
+++ b/doc/guide/usage.rst
@@ -393,6 +393,10 @@ The following options are available on all Cask commands:
 
    Show all output from `package.el`.
 
+.. option:: --load-path <directory>
+
+   Add :file:`directory` to Emacs load-path before running command.
+
 Environment variables
 =====================
 

--- a/features/load-path-option.feature
+++ b/features/load-path-option.feature
@@ -1,0 +1,35 @@
+Feature: Load path option
+  Extend load path with directory
+
+  Background:
+    Given this Cask file:
+      """
+      (files "lisp/foo.el")
+      """
+    And I create a directory called "lisp"
+    And I create a file called "lisp/foo.el" with content:
+      """
+      (require 'bar)
+      """
+    And I create a file called "lisp/bar.el" with content:
+      """
+      (provide 'bar)
+      """
+
+  Scenario: Not in load-path
+    When I run cask "build"
+    Then I should see command output:
+      """
+      Cannot open load file: no such file or directory, bar
+      """
+
+  Scenario: Added to load-path
+    When I run cask "build --load-path lisp"
+    Then I should see command output pattern:
+      """
+      Compiling .+foo.el
+      """
+    And I should see command output pattern:
+      """
+      Wrote .+foo.elc
+      """

--- a/features/step-definitions/cask-steps.el
+++ b/features/step-definitions/cask-steps.el
@@ -44,6 +44,10 @@
   (lambda (content)
     (f-write-text content 'utf-8 (f-expand "Cask" cask-test/sandbox-path))))
 
+(Given "^I create a directory called \"\\([^\"]+\\)\"$"
+  (lambda (dirname)
+    (f-mkdir (f-expand dirname cask-test/sandbox-path))))
+
 (Given "^I create a file called \"\\([^\"]+\\)\" with content:$"
   (lambda (filename content)
     (f-write-text content 'utf-8 (f-expand filename cask-test/sandbox-path))))
@@ -74,6 +78,10 @@
 (Then "^I should see command output:$"
   (lambda (output)
     (should (s-contains? output cask-test/stdout))))
+
+(Then "^I should see command output pattern:$"
+  (lambda (pattern)
+    (should (s-matches? pattern cask-test/stdout))))
 
 (Then "^I should not see command error:$"
   (lambda (output)


### PR DESCRIPTION
The option takes one argument that is added to Emacs load-path before
the Cask command runs.
