### PR TITLE
Use the systems temporary file directory

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -182,7 +182,7 @@ the function `cask--with-environment'.")
   "List of supported fetchers.")
 
 (defconst cask-tmp-path
-  (f-expand "tmp" cask-directory))
+  (f-expand "cask" temporary-file-directory))
 
 (defconst cask-tmp-checkout-path
   (f-expand "checkout" cask-tmp-path))


### PR DESCRIPTION
I propose this change to make Cask work well when installed with a package manager (i.e. not having write access to the installation directory). Using the real temp directory has other advantages and I couldn't find a reason not to use it by default.