### PR TITLE
Adds support for eval command.

### DIFF
--- a/Cask
+++ b/Cask
@@ -15,4 +15,5 @@
  (depends-on "ert-runner")
  (depends-on "el-mock")
  (depends-on "noflet")
- (depends-on "ert-async"))
+ (depends-on "ert-async")
+ (depends-on "shell-split-string"))

--- a/cask-cli.el
+++ b/cask-cli.el
@@ -224,6 +224,20 @@ directory called bin in the root directory.
 The output is formatted as a colon path."
   (princ (concat (s-join path-separator (cask-exec-path (cask-cli--bundle))) "\n")))
 
+(defmacro cask-cli--with-package-path (&rest body)
+  "Execute BODY with `load-path' set according to the project."
+  (declare (debug t))
+  `(let ((load-path
+          (cask-load-path (cask-cli--bundle))))
+     (add-to-list 'load-path
+                  cask-cli--path)
+     ,@body))
+
+(defun cask-cli/eval (form)
+  "Eval FORM with the `load-path' set according to the project."
+  (cask-cli--with-package-path
+   (eval (read form))))
+
 (defun cask-cli/package-directory ()
   "Print current package installation directory."
   (princ (concat (cask-elpa-path (cask-cli--bundle)) "\n")))
@@ -365,6 +379,7 @@ Commands:
  (command "help [command]" cask-cli/help)
  (command "load-path" cask-cli/load-path)
  (command "exec-path" cask-cli/exec-path)
+ (command "eval <form>" cask-cli/eval)
  (command "path" cask-cli/exec-path)
  (command "package-directory" cask-cli/package-directory)
  (command "outdated" cask-cli/outdated)

--- a/doc/guide/usage.rst
+++ b/doc/guide/usage.rst
@@ -75,6 +75,24 @@ Execute the system :var:`command` with the given :var:`arguments`, with a
 proper `$PATH` (see :ref:`cask path`) and `$EMACSLOADPATH` (see :ref:`cask
 load-path`).
 
+
+.. _cask eval:
+
+cask eval
+---------
+
+.. program:: cask eval
+
+::
+
+   cask [GLOBAL-OPTIONS] eval [FORM]
+
+Evaluate ``FORM`` as a lisp form with a proper `$PATH` (see :ref:`cask path`)
+and $EMACSLOADPATH (see :ref:`cask load-path`). The return value of the form
+is not printed directly: ``FORM`` must print to the standard out or error
+stream.            
+
+
 .. _cask help:
 
 cask help

--- a/features/eval.feature
+++ b/features/eval.feature
@@ -1,0 +1,18 @@
+Feature: Eval
+  Link local packages
+
+  Scenario: No arguments
+    Given this Cask file:
+      """
+      (package "super-project" "0.0.1" "Super project.")
+      """
+    When I run cask "eval '(print nil)'"
+    Then I should not see command error:
+      """
+      Wrong type argument: stringp, nil
+      """
+    But I should see command output:
+      """
+
+      nil
+      """

--- a/features/step-definitions/cask-steps.el
+++ b/features/step-definitions/cask-steps.el
@@ -34,6 +34,8 @@
   (defvar cask-test/stdout)
   (defvar cask-test/stderr))
 
+(require 'shell-split-string)
+
 (defun cask-test/template (command)
   "Return COMMAND with placeholders replaced with values."
   (->> command
@@ -48,7 +50,7 @@
   (lambda (filename content)
     (f-write-text content 'utf-8 (f-expand filename cask-test/sandbox-path))))
 
-(When "^I run cask \"\\([^\"]*\\)\"$"
+(When "^I run cask \"\\(.*\\)\"$"
   (lambda (command)
     ;; Note: Since the Ecukes tests runs with Casks dependencies in
     ;; EMACSLOADPATH, these will also be available in the subprocess
@@ -56,7 +58,7 @@
     (setenv "EMACSLOADPATH" (s-join path-separator (--reject (s-matches? ".cask" it) load-path)))
     (with-temp-buffer
       (let* ((default-directory (f-full cask-test/sandbox-path))
-             (args (s-split " " (cask-test/template command)))
+             (args (shell-split-string (cask-test/template command)))
              (exit-code
               (apply
                'call-process


### PR DESCRIPTION
I added this command so I could check which Emacs version was running, but it seems that it might be more generically useful. Will patch up the documentation iff you think its worth while.


This allows executing arbitrary lisp in the context of the current
project.