### PR TITLE
Fix for issue #285 PY3 and Windows: TypeError exception

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -254,7 +254,10 @@ def get_cask_emacs():
     # compile.  In this case, $EMACS may be set as well to a rather
     # meaningless value.  If $INSIDE_EMACS is set, we just ignore the
     # value of $EMACS.
-    emacs = ENVB.get(b'EMACS') if b'INSIDE_EMACS' not in ENVB else None
+    if sys.version_info[0] == 2:
+        emacs = ENVB.get(b'EMACS') if b'INSIDE_EMACS' not in ENVB else None
+    else:
+        emacs = ENVB.get('EMACS') if 'INSIDE_EMACS' not in ENVB else None
     emacs = emacs or find_best_emacs()
     ensure_supported_emacs(emacs)
     return emacs


### PR DESCRIPTION
Fix for issue #285 PY3 and Windows: TypeError when checking if INSIDE_EMACS is in ENVB

With this fix I was able to successfully install Cask and install my dependencies under Windows.
If you have the same issue please test this and react on this PR since I was the only one that tested it.

The changes are not as nice as I would normally make it, but at this moment I have no inspiration for a good refactor of the change which solves the problem and is compatible with both PY2 and PY3. Suggestions are welcome. 