### PR TITLE
Fix package command argument handling

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -919,7 +919,8 @@ a directory specified by `cask-dist-path' in the BUNDLE path."
         (setq target-dir (f-expand cask-dist-path path)))
       (unless (f-dir? target-dir)
         (f-mkdir target-dir))
-      (package-build-package name version patterns path target-dir))))
+      (package-build-package name version patterns path
+                             (expand-file-name target-dir)))))
 
 (provide 'cask)
 


### PR DESCRIPTION
A command like

```
$ cask package dist
```

may fail to create a package, because `package-build--build-multi-file-package` may change the `default-directory` and the package does end up in some temporary directory.
