### PR TITLE
wrong package version in pkg file fixed

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -730,7 +730,7 @@ If DEEP is t, all dependencies recursively will be returned."
            (-map
             (lambda (dependency)
               (list (cask-dependency-name dependency)
-                    (cask-dependency-version dependency)))
+            	    (or (cask-dependency-version dependency) "0")))
             (cask--runtime-dependencies bundle))))
       (pp-to-string `(define-package ,name ,version ,description ',dependencies)))))
 


### PR DESCRIPTION
We have to provide "0" as package version for packages which does not have specific version in `Cask` file. Currently we put `nil` which is wrong and it cause cask to throw an error in installation time:

pkg file example:

``` lisp
(define-package "fg42-core" "1.0.0" "a simple package"
  '((dired+ nil)
    (flx-ido nil)
    (expand-region nil)
    (multiple-cursors nil)
    (ido-vertical-mode nil)
    (ido nil)
    (color-theme nil)))
```

error example 

``` bash
Package initialization failed: Invalid version string: 'nil'
Output:
Importing package-keyring.gpg...
Importing package-keyring.gpg...done
Contacting host: elpa.gnu.org:80
Contacting host: melpa.org:80
Package refresh done
```

/CC @rejeep 
