### PR TITLE
Use HTTPS to connect to sources that support it

### DIFF
--- a/cask-bootstrap.el
+++ b/cask-bootstrap.el
@@ -52,8 +52,8 @@
         (condition-case nil
             (mapc 'require cask-bootstrap-packages)
           (error
-           (add-to-list 'package-archives (cons "gnu" "http://elpa.gnu.org/packages/"))
-           (add-to-list 'package-archives (cons "melpa" "http://melpa.org/packages/"))
+           (add-to-list 'package-archives (cons "gnu" "https://elpa.gnu.org/packages/"))
+           (add-to-list 'package-archives (cons "melpa" "https://melpa.org/packages/"))
            (package-refresh-contents)
            (mapc
             (lambda (package)

--- a/cask-cli.el
+++ b/cask-cli.el
@@ -145,8 +145,8 @@ Git is available in `exec-path'."
         (progn
           (epl-change-package-dir cask-bootstrap-dir)
           (epl-initialize)
-          (epl-add-archive "gnu" "http://elpa.gnu.org/packages/")
-          (epl-add-archive "melpa" "http://melpa.org/packages/")
+          (epl-add-archive "gnu" "https://elpa.gnu.org/packages/")
+          (epl-add-archive "melpa" "https://melpa.org/packages/")
           (epl-refresh)
           (epl-upgrade))
       (epl-reset))

--- a/cask.el
+++ b/cask.el
@@ -157,10 +157,10 @@ Slots:
   line column)
 
 (defvar cask-source-mapping
-  '((gnu          . "http://elpa.gnu.org/packages/")
-    (melpa        . "http://melpa.org/packages/")
-    (melpa-stable . "http://stable.melpa.org/packages/")
-    (marmalade    . "http://marmalade-repo.org/packages/")
+  '((gnu          . "https://elpa.gnu.org/packages/")
+    (melpa        . "https://melpa.org/packages/")
+    (melpa-stable . "https://stable.melpa.org/packages/")
+    (marmalade    . "https://marmalade-repo.org/packages/")
     (SC           . "http://joseito.republika.pl/sunrise-commander/")
     (org          . "http://orgmode.org/elpa/"))
   "Mapping of source name and url.")

--- a/doc/guide/dsl.rst
+++ b/doc/guide/dsl.rst
@@ -109,7 +109,7 @@ Dependencies
    Cask includes the following built-in package archives:
 
    `gnu`
-      The standard GNU ELPA archive at http://elpa.gnu.org/.
+      The standard GNU ELPA archive at https://elpa.gnu.org/.
 
       .. warning::
 
@@ -119,15 +119,15 @@ Dependencies
 
    `melpa-stable`
       An archive of stable versions built automatically from upstream
-      repositories, at http://melpa-stable.milkbox.net/.
+      repositories, at https://melpa-stable.milkbox.net/.
 
    `melpa`
       An archive of VCS snapshots built automatically from upstream
-      repositories, at http://melpa.org/.
+      repositories, at https://melpa.org/.
 
    `marmalade`
       An archive of packages uploaded by users and maintainers, at
-      http://marmalade-repo.org/.
+      https://marmalade-repo.org/.
 
    `SC`
       An archive providing packages for `Sunrise Commander`_, at

--- a/package-legacy.el
+++ b/package-legacy.el
@@ -217,7 +217,7 @@ If VERSION is nil, the package is not loaded (it is \"disabled\")."
 (declare-function lm-commentary "lisp-mnt" (&optional file))
 (defvar url-http-end-of-headers)
 
-(defcustom package-archives '(("gnu" . "http://elpa.gnu.org/packages/"))
+(defcustom package-archives '(("gnu" . "https://elpa.gnu.org/packages/"))
   "An alist of archives from which to fetch.
 The default value points to the GNU Emacs package repository.
 

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -863,10 +863,10 @@
   (cask-test/with-bundle
       '((package "package-a" "0.0.1" "PACKAGE-A"))
     (should-not (cask-bundle-sources bundle))
-    (cask-add-source bundle "melpa" "http://melpa.org/packages/")
+    (cask-add-source bundle "melpa" "https://melpa.org/packages/")
     (let ((source (car (cask-bundle-sources bundle))))
       (should (string= (cask-source-name source) "melpa"))
-      (should (string= (cask-source-url source) "http://melpa.org/packages/")))))
+      (should (string= (cask-source-url source) "https://melpa.org/packages/")))))
 
 (ert-deftest cask-add-source-test/alias ()
   (cask-test/with-bundle
@@ -875,7 +875,7 @@
     (cask-add-source bundle 'melpa)
     (let ((source (car (cask-bundle-sources bundle))))
       (should (string= (cask-source-name source) "melpa"))
-      (should (string= (cask-source-url source) "http://melpa.org/packages/")))))
+      (should (string= (cask-source-url source) "https://melpa.org/packages/")))))
 
 
 ;;;; cask-remove-source


### PR DESCRIPTION
HTTP sends plaintext messages, so it leaks information and is vulnerable to MITM attacks. ELPA, MELPA, and Marmalade all support HTTPS. We should make use of it.

This changes the default addresses for those sources to use HTTPS. Users that have built Emacs to handle TLS will be able to make use of these sources, and Emacs will fall back to using regular HTTP if it isn't configured to handle TLS.

This also updates the documentation to point to the HTTPS address of those repositories.

This should close https://github.com/cask/cask/issues/323.