### PR TITLE
Ci and package toolset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ env:
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
 script:
+  - emacs --version
   - make test
+
 after_failure:
   - cat test/servant/tmp/servant.log
 after_script:

--- a/Cask
+++ b/Cask
@@ -16,4 +16,6 @@
  (depends-on "el-mock")
  (depends-on "noflet")
  (depends-on "ert-async")
- (depends-on "shell-split-string"))
+ (depends-on "shell-split-string")
+ (depends-on "cask-package-toolset")
+ (depends-on "undercover"))

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 ![Cask](cask.png)
 
+[![Build Status](https://travis-ci.org/cask/cask.svg)](https://travis-ci.org/cask/cask)
+[![Coverage Status](https://coveralls.io/repos/cask/cask/badge.svg)](https://coveralls.io/r/cask/cask)
+[![MELPA](http://melpa.org/packages/cask-badge.svg)](http://melpa.org/#/cask)
+[![MELPA stable](http://stable.melpa.org/packages/cask-badge.svg)](http://stable.melpa.org/#/cask)
+[![Tag Version](https://img.shields.io/github/tag/cask/cask.svg)](https://github.com/cask/cask/tags)
+[![License](http://img.shields.io/:license-gpl3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0.html)
+
 Cask is a project management tool for Emacs that helps automate the
 package development cycle; development, dependencies, testing,
 building, packaging and more.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Cask](cask.png)
 
+
 [![Build Status](https://travis-ci.org/cask/cask.svg)](https://travis-ci.org/cask/cask)
 [![Coverage Status](https://coveralls.io/repos/cask/cask/badge.svg)](https://coveralls.io/r/cask/cask)
 [![MELPA](http://melpa.org/packages/cask-badge.svg)](http://melpa.org/#/cask)
@@ -9,28 +10,54 @@
 [![Tag Version](https://img.shields.io/github/tag/cask/cask.svg)](https://github.com/cask/cask/tags)
 [![License](http://img.shields.io/:license-gpl3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0.html)
 
-Cask is a project management tool for Emacs that helps automate the
+Cask is a *project management tool* for Emacs that helps automate the
 package development cycle; development, dependencies, testing,
 building, packaging and more.
 
-Cask can also be used to manage dependencies for your local Emacs
-configuration.
+Cask can also be used to manage dependencies for your local Emacs configuration.
 
-To install Cask, run this command:
+## Basic Usage
+
+`cask` is both command suite and a way to describe the dependencies in a `Cask` file.
+
+### Main Command
+
+Here are the main commands to start with:
+- `install` : install Cask dependancies
+- `exec` : run command in the good cask context
+- `init` : to initiate a project
+For complete reference, run `cask help` or consult [online documentation](http://cask.readthedocs.org/en/latest/guide/usage.html)
+
+### Minimal Cask file
+
+A new `Cask` file can be easily generated with the `init --dev` command.
+```lisp
+(source melpa)
+
+(package-file "my-pkg.el")
+
+(development
+ (depends-on "ert")
+```
+
+
+See <http://cask.readthedocs.org/> for more information and
+<https://groups.google.com/forum/#!forum/cask-dev> for development
+related discussion.
+
+## Install
+
+To install `Cask`, run this command:
 
 ```bash
 $ curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 ```
 
-Or if you are on a Mac, you can install Cask via Homebrew:
+Or if you are on a Mac, you can install `Cask` via Homebrew:
 
 ```bash
 $ brew install cask
 ```
-
-See <http://cask.readthedocs.org/> for more information and
-<https://groups.google.com/forum/#!forum/cask-dev> for development
-related discussion.
 
 ## License
 

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -30,6 +30,7 @@
 (require 'dash)
 (require 'espuds)
 (require 'ansi)
+(require 'noflet)
 
 (defvar cask-test/features-path
   (f-parent (f-parent load-file-name)))

--- a/templates/init-dev.tpl
+++ b/templates/init-dev.tpl
@@ -7,4 +7,5 @@
  (depends-on "f")
  (depends-on "ecukes")
  (depends-on "ert-runner")
- (depends-on "el-mock"))
+ (depends-on "el-mock")
+ (depends-on "cask-package-toolset"))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -32,6 +32,13 @@
 (require 'el-mock)
 (require 'ert-async)
 
+(require 'undercover)
+(undercover "*.el"
+            (:exclude "*-test.el")
+            (:send-report nil)
+            (:report-file "/tmp/undercover-report.json"))
+
+
 (defconst cask-test/test-path
   (f-parent (f-this-file)))
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -35,7 +35,6 @@
 (require 'undercover)
 (undercover "*.el"
             (:exclude "*-test.el")
-            (:send-report nil)
             (:report-file "/tmp/undercover-report.json"))
 
 


### PR DESCRIPTION
Improved CI and README:

have a look here: 
- README: https://github.com/AdrieanKhisbe/cask/tree/ci-and-package-toolset
- build: https://travis-ci.org/AdrieanKhisbe/cask/builds
- coverage: https://coveralls.io/github/AdrieanKhisbe/cask

What PR consist:
- Update of travis with evm 0.7 (-> containers, evm-travis)
- coverage for unit test. 
- ci badge to README
-  some more introduction to README
- scaffolded `Cask`  file now countain [cask-package-toolset](https://github.com/AdrieanKhisbe/cask-package-toolset.el), tool to help set up CI on cask project.

What could be idealy done:
add coverage for features test, but that would require to ack around (cf https://github.com/AdrieanKhisbe/cask-package-toolset.el/blob/master/features/step-definitions/cask-package-toolset-steps.el#L7-L28)
