### PR TITLE
Fix for Windows when cask path contains spaces.

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -275,7 +275,7 @@ def exec_command(command):
     # Copy the environment and update the paths
     ENVB[b'EMACSLOADPATH'] = get_cask_path('load-path')
     ENVB[b'PATH'] = get_cask_path('path')
-    os.execvp(command[0], command)
+    subprocess.call(command)
 
 
 def exec_cask(arguments):
@@ -292,7 +292,7 @@ def exec_cask(arguments):
     emacs = get_cask_emacs()
     cli = os.path.join(CASK_DIRECTORY, 'cask-cli.el')
     command = [emacs, '-Q', '--script', cli, '--'] + arguments
-    os.execvp(command[0], command)
+    subprocess.call(command)
 
 
 def exit_error(error):

--- a/bin/cask.bat
+++ b/bin/cask.bat
@@ -1,5 +1,5 @@
 @echo off
-python %~dp0cask %*
+python "%~dp0cask" %*
 
 REM %~dp0 expands to match CASK_BIN_DIRECTORY.
 REM %* passes all arguments to "python cask"


### PR DESCRIPTION
In windows if the cask install path contains spaces, cask doesn't work. This is because os.execvp can't handle spaces in path in windows.