### PR TITLE
Add an Emacs command, to run Emacs directly.

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -323,6 +323,21 @@ def exec_command(command):
         raise ExecCommandError(command, error)
 
 
+def exec_emacs(command):
+    """Execute Emacs with the proper Cask environment.
+
+    ``command`` is a list of strings, containing the arguments to pass to the
+    emacs process. The Emacs executable is choosen according to the normal
+    rules (see ``get_cask_emacs``). Set ``$PATH`` and ``$EMACSLOADPATH`` to
+    include the Cask package environment.
+
+    This function replaces the current process.  It does **not** return.
+
+    """
+    command.insert([get_cask_emacs()] + command)
+    exec_command(command)
+
+
 def exec_cask(arguments):
     """Execute the Cask CLI with the given ``arguments``.
 
@@ -369,8 +384,11 @@ def main():
             exit_error(
                 'Python 2.6 required, yours is {0.major}.{0.minor}'.format(
                     sys.version_info))
+        ## TODO: replace with a command line parser!
         if len(sys.argv) > 1 and sys.argv[1] == 'exec':
             exec_command(sys.argv[2:])
+        elif len(sys.argv) > 1 and sys.argv[1] == 'emacs':
+            exec_emacs(sys.argv[2:])
         else:
             exec_cask(sys.argv[1:])
     except OSError as error:

--- a/doc/guide/usage.rst
+++ b/doc/guide/usage.rst
@@ -44,6 +44,11 @@ To install all dependencies, run:
 This will create a directory called `.cask` and install all dependencies into
 it.
 
+.. _finding_emacs:
+
+Finding Emacs
+-------------
+
 By default, packages are installed for the default Emacs, i.e. the one behind
 the `emacs` command.  To pick a different Emacs, set the environment variable
 :envvar:`EMACS` to the command name or executable path of the Emacs to use:
@@ -81,6 +86,21 @@ cask exec
 Execute the system :var:`command` with the given :var:`arguments`, with a
 proper `$PATH` (see :ref:`cask path`) and `$EMACSLOADPATH` (see :ref:`cask
 load-path`).
+
+
+.. _cask emacs:
+
+cask emacs
+----------
+
+.. program:: cask emacs
+
+::
+   cask [GLOBAL-OPTIONS] emacs [ARGUMENTS ...]
+
+Execute `emacs` with the given :var:`arguments`, with the appropriate
+environmment (see :ref:`cask exec`). The Emacs executable is that which cask
+would normally run in (see :ref:`finding_emacs`).
 
 
 .. _cask eval:


### PR DESCRIPTION
Partly this saves a bit of typing (i.e. `cask emacs` rather than `cask exec emacs`), but mostly because it ensures that the same Emacs is run as would normally be the case.