### PR TITLE
Provide emacs-with-cask

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -337,6 +337,13 @@ def exec_emacs(command):
     exec_command([get_cask_emacs()] + command)
 
 
+def exec_emacs_with_cask(command):
+    ENVB[b'CASK_DIRECTORY'] = CASK_DIRECTORY
+    exec_command([get_cask_emacs(), "--load"] +
+                 ["{}/cask-init.el".format(CASK_DIRECTORY)] +
+                 command)
+
+
 def exec_cask(arguments):
     """Execute the Cask CLI with the given ``arguments``.
 
@@ -388,6 +395,8 @@ def main():
             exec_command(sys.argv[2:])
         elif len(sys.argv) > 1 and sys.argv[1] == 'emacs':
             exec_emacs(sys.argv[2:])
+        elif len(sys.argv) > 1 and sys.argv[1] == "emacs-with-cask":
+            exec_emacs_with_cask(sys.argv[2:])
         else:
             exec_cask(sys.argv[1:])
     except OSError as error:

--- a/cask-init.el
+++ b/cask-init.el
@@ -1,0 +1,41 @@
+;;; cask-init.el --- Set up an Emacs
+
+;; Copyright (C) 2016 Phillip Lord
+
+;; Author: Phillip Lord <phillip.lord@russet.org.uk>
+;; Maintainer: Phillip Lord <phillip.lord@russet.org.uk>
+;; URL: http://github.com/cask/cask
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Set up an Emacs, probably running in batch so that it is fully casked.
+
+;; This is intended for internal use by Cask
+
+;;; Code:
+(add-to-list 'load-path default-directory)
+
+
+(require 'cask (concat
+                (getenv "CASK_DIRECTORY")
+                "/cask.el"))
+
+(cask-initialize default-directory)
+
+(provide 'cask-init)
+;;; cask-init.el ends here


### PR DESCRIPTION
Allow running an emacs setup to use local cask settings
but with full access to other command line arguments.

Not a real PR at the moment, just thinking out load. I'm wondering whether the emacs command I have added is quite the right thing. It's useful, but it doesn't set up the environment as an Emacs running cask would.

This version (emacs-with-cask -- bad name) does this. It allows me to do things like

    cask emacs-with-cask -q --batch --eval '(message "hello world")'

which replicates the existing `cask eval` command. But I can also do

    cask emacs-with-cask -q --batch --load blah.el -f blah-run-everything-interesting

So, instead of adding as well as "eval", a load-file, a run function and other options to cask, we just let the Emacs command line parser do all the work. We can't get this functionality at the moment AFAICT, with the `emacs` command because it doesn't know where `cask.el` is.

Perhaps there is a better way to do this, and I am missing something that cask already does. Other thoughts -- is "emacs-with-cask" sensible, and perhaps this should just be the behaviour of the "emacs" command. And, if emacs-with-cask is sensible, this is probably the right time to put a proper python command line parser into cask. Or, perhaps, just add CASK_DIRECTORY to the environment of the Emacs command and let people do this for themselves.

Obviously, docstrings, manual and (this time) tests would be added also.