### PR TITLE
Add error if cask install has not been run

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -90,6 +90,19 @@ class MissingEmacsError(Exception):
         self.emacs = emacs
 
 
+class MissingPackageError(Exception):
+    """An exception indicating that one or more direct dependencies are missing.
+
+    The ```report``` attribute describes the missing dependencies in a
+    human-readable form.
+
+    """
+
+    def __init__(self, report):
+        Exception.__init__(self)
+        self.report = report
+
+
 class EmacsCommandError(Exception):
     """An exception indicating a failed Emacs command.
 
@@ -153,18 +166,35 @@ def format_version(version):
     return '.'.join(str(part) for part in version)
 
 
+def get_missing_packages():
+    """Get a report of the missing direct dependencies.
+
+    The report is a human-readable list of the any direct dependencies which are
+    required but not present. The empty string is returned if there are none.
+
+    """
+    process = subprocess.Popen([sys.executable, CASK, "missing"], stdout=subprocess.PIPE)
+    stdout, _ = process.communicate()
+
+    return stdout.rstrip()
+
+
 def get_cask_path(kind):
     """Get the Cask package environment path of the given ``kind``.
 
     ``kind`` is a string, denoting the kind of the path to get.  Cask supports
-    two different kinds, namely ``'path'`` for the executable path of the
-    package environment, and ``'load-path'`` for the Emacs Lisp load path of
-    the package environment.
+    three different kinds, namely ``'path'`` for the executable path of the
+    package environment, ``'load-path'`` for the Emacs Lisp load path of
+    the package environment and ``'package-directory'``.
 
     Return the path as string, which contains all directories of the path
     separated by path separators.
 
     """
+    missing = get_missing_packages()
+    if (missing):
+        raise MissingPackageError(missing)
+
     process = subprocess.Popen([sys.executable, CASK, kind], stdout=subprocess.PIPE)
     stdout, _ = process.communicate()
     return stdout.rstrip()
@@ -400,6 +430,8 @@ def main():
         exit_error(
             'Emacs does not exist at {0}.  Did you install Emacs?'.format(
                 error.emacs))
+    except MissingPackageError as error:
+        exit_error("Missing Packages\n{}\nDo you need to run cask install?".format(error.report))
     except EmacsCommandError as error:
         exit_error('Emacs command "{0}" failed: {1}'.format(
             error.command, error.real_error))

--- a/doc/guide/usage.rst
+++ b/doc/guide/usage.rst
@@ -96,6 +96,7 @@ cask emacs
 .. program:: cask emacs
 
 ::
+
    cask [GLOBAL-OPTIONS] emacs [ARGUMENTS ...]
 
 Execute `emacs` with the given :var:`arguments`, with the appropriate
@@ -220,6 +221,19 @@ cask outdated
    cask [GLOBAL-OPTIONS] outdated
 
 Show all outdated dependencies.
+
+.. _cask missing:
+
+cask missing
+------------
+
+.. program:: cask missing
+
+::
+
+   cask [GLOBAL-OPTIONS] missing
+
+Show immediate dependencies which have not been installed.
 
 .. _cask pkg-file:
 

--- a/features/emacs.feature
+++ b/features/emacs.feature
@@ -6,7 +6,8 @@ Feature: Eval
       """
       (package "super-project" "0.0.1" "Super project.")
       """
-    When I run cask "emacs -q --batch --eval '(print nil)'"
+    When I run cask "install"
+    And I run cask "emacs -q --batch --eval '(print nil)'"
     Then I should not see command error:
       """
       Wrong type argument: stringp, nil

--- a/features/eval.feature
+++ b/features/eval.feature
@@ -6,7 +6,8 @@ Feature: Eval
       """
       (package "super-project" "0.0.1" "Super project.")
       """
-    When I run cask "eval '(print nil)'"
+    When I run cask "install"
+    And I run cask "eval '(print nil)'"
     Then I should not see command error:
       """
       Wrong type argument: stringp, nil

--- a/features/exec.feature
+++ b/features/exec.feature
@@ -5,7 +5,8 @@ Feature: Exec
     Given this Cask file:
       """
       """
-    When I run cask "exec echo foo"
+    When I run cask "install"
+    And I run cask "exec echo foo"
     Then I should see command output:
       """
       foo
@@ -58,9 +59,25 @@ Feature: Exec
     Given this Cask file:
       """
       """
-    When I run cask "exec does-not-exist"
+    When I run cask "install"
+    And I run cask "exec does-not-exist"
     Then I should see command error:
       """
       cask exec: error: Failed to execute does-not-exist: [Errno 2] No such file or directory
       Did you run cask install?
+      """
+
+  Scenario: install has not been run
+    Given this Cask file:
+      """
+      (source "localhost" "http://127.0.0.1:9191/packages/")
+
+      (depends-on "package-c" "0.0.1")
+      """
+    When I run cask "exec true"
+    Then I should see command error:
+      """
+      cask exec: error: Missing Packages
+      package-c
+      Do you need to run cask install?
       """

--- a/features/missing.feature
+++ b/features/missing.feature
@@ -1,0 +1,45 @@
+Feature: Missing
+  List missing dependencies
+
+  Scenario: No dependencies
+    Given this Cask file:
+    """
+    (source "localhost" "http://127.0.0.1:9191/packages/")
+    """
+    When I run cask "missing"
+    Then I should see no command output
+
+  Scenario: With dependencies
+    Given this Cask file:
+    """
+    (source "localhost" "http://127.0.0.1:9191/packages/")
+    (depends-on "package-a" "0.1.2")
+    (depends-on "package-b" "0.2.1")
+
+    (development
+      (depends-on "package-c")
+      (depends-on "package-d"))
+    """
+    When I run cask "install"
+    And I run cask "missing"
+    Then I should see no command output
+
+  Scenario: With missing dependencies
+    Given this Cask file:
+    """
+    (source "localhost" "http://127.0.0.1:9191/packages/")
+    (depends-on "package-a" "0.1.2")
+    (depends-on "package-b" "0.2.1")
+
+    (development
+      (depends-on "package-c")
+      (depends-on "package-d"))
+    """
+    When I run cask "missing"
+    Then I should see command output:
+    """
+    package-b
+    package-a
+    package-d
+    package-c
+    """

--- a/features/step-definitions/cask-steps.el
+++ b/features/step-definitions/cask-steps.el
@@ -85,6 +85,10 @@
   (lambda (output)
     (should-not (s-contains? output cask-test/stdout))))
 
+(Then "^I should see no command output$"
+  (lambda ()
+    (should (s-blank? cask-test/stdout))))
+
 (Then "^I should see usage information$"
   (lambda ()
     (should (s-contains? "USAGE: cask [COMMAND] [OPTIONS]" cask-test/stdout))))


### PR DESCRIPTION
Cask now checks for the presence of an ELPA directory, and signals an
error if it does not exist for all commands where the ELPA directory
will change the result of the output.
