### PR TITLE
Exit build command with proper status code

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -52,6 +52,9 @@
 (defvar cask-cli--path default-directory
   "Cask commands will execute in this path.")
 
+(defvar cask-cli--warn-as-error nil
+  "Consider warnings as error.")
+
 (defvar cask-cli--bundle-cache nil)
 
 (defun cask-cli--bundle ()
@@ -260,8 +263,14 @@ If no files directive or no files, do nothing."
       (princ (concat file "\n")))))
 
 (defun cask-cli/build ()
-  "Build all Elisp files in the files directive."
-  (cask-build (cask-cli--bundle)))
+  "Build all Elisp files in the files directive.
+
+Exit code is 1 if any of the files contained a compile error, 0
+otherwise."
+  (let ((result (cask-build (cask-cli--bundle) :warn-as-error cask-cli--warn-as-error)))
+    (if result
+        (kill-emacs 0)
+      (kill-emacs 1))))
 
 (defun cask-cli/clean-elc ()
   "Remove all byte compiled Elisp files in the files directive."
@@ -357,6 +366,10 @@ Commands:
   "Be verbose and do not hide output."
   (setq shut-up-ignore t))
 
+(defun cask-cli/warn-as-error ()
+  "Consider compiler warnings as errors."
+  (setq cask-cli--warn-as-error t))
+
 
 ;;;; Commander schedule
 
@@ -399,7 +412,8 @@ Commands:
  (option "--dev" cask-cli/dev)
  (option "--debug" cask-cli/debug)
  (option "--path <path>" cask-cli/set-path)
- (option "--verbose" cask-cli/verbose))
+ (option "--verbose" cask-cli/verbose)
+ (option "--warn-as-error" cask-cli/warn-as-error))
 
 (provide 'cask-cli)
 

--- a/doc/guide/usage.rst
+++ b/doc/guide/usage.rst
@@ -310,6 +310,16 @@ cask build
 Byte compile all Emacs Lisp files in the package.  The resulting byte code is
 written to the original path, with the extension replaced by ``.elc``.
 
+Exit code is ``1`` if any of the files contained a compile error,
+``0`` otherwise.
+
+.. option:: --warn-as-error
+
+   Consider compiler warnings as errors. This means that if a file
+   contains a warning and this flag is used, the exit code will be
+   ``1`` instead of ``0``.
+
+
 .. _cask clean-elc:
 
 cask clean-elc

--- a/features/build.feature
+++ b/features/build.feature
@@ -1,0 +1,40 @@
+Feature: Build
+  Build package files
+
+  Background:
+    Given this Cask file:
+      """
+      (files "foo.el")
+      """
+
+  Scenario: No error or warning
+    Given I create a file called "foo.el" with content:
+      """
+      (print "Hello World!")
+      """
+    When I run cask "build"
+    Then last command exited with status code "0"
+
+  Scenario: With warning
+    Given I create a file called "foo.el" with content:
+      """
+      (next-line 1)
+      """
+    When I run cask "build"
+    Then last command exited with status code "0"
+
+  Scenario: With warning (with warn as error flag)
+    Given I create a file called "foo.el" with content:
+      """
+      (next-line 1)
+      """
+    When I run cask "build --warn-as-error"
+    Then last command exited with status code "1"
+
+  Scenario: With error
+    Given I create a file called "foo.el" with content:
+      """
+      (require 'does-not-exit)
+      """
+    When I run cask "build"
+    Then last command exited with status code "1"

--- a/features/step-definitions/cask-steps.el
+++ b/features/step-definitions/cask-steps.el
@@ -32,7 +32,8 @@
   (defvar cask-test/sandbox-path)
   (defvar cask-test/bin-command)
   (defvar cask-test/stdout)
-  (defvar cask-test/stderr))
+  (defvar cask-test/stderr)
+  (defvar cask-test/exit-code))
 
 (require 'shell-split-string)
 
@@ -63,6 +64,7 @@
               (apply
                'call-process
                (append (list cask-test/bin-command nil (current-buffer) nil) args))))
+        (setq cask-test/exit-code exit-code)
         (let ((content (buffer-string)))
           (cond ((= exit-code 0)
                  (setq cask-test/stdout content))
@@ -96,6 +98,10 @@
 (Then "^package \"\\([^\"]+\\)\" should not be installed$"
   (lambda (package)
     (should-not (f-dir? (f-join cask-test/sandbox-path ".cask" emacs-version "elpa" package)))))
+
+(Then "^last command exited with status code \"\\([^\"]+\\)\"$"
+  (lambda (exit-code)
+    (should (eq (string-to-number exit-code) cask-test/exit-code))))
 
 (provide 'cask-steps)
 

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -51,6 +51,7 @@
 
 (defvar cask-test/stderr)
 (defvar cask-test/stdout)
+(defvar cask-test/exit-code)
 
 (add-to-list 'load-path cask-test/root-path)
 
@@ -60,6 +61,7 @@
 (Before
  (setq cask-test/stderr "")
  (setq cask-test/stdout "")
+ (setq cask-test/exit-code nil)
 
  (when (f-dir? cask-test/sandbox-path)
    (f-delete cask-test/sandbox-path 'force))

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -928,6 +928,37 @@
     (cask-install bundle)
     (cask-build bundle)))
 
+(ert-deftest cask-build-test/return-value-no-error-or-warning ()
+  (cask-test/with-bundle '((files "foo.el"))
+    (f-write-text "(print \"Hello World!\")" 'utf-8 "foo.el")
+    (cask-install bundle)
+    (should (cask-build bundle))))
+
+(ert-deftest cask-build-test/return-value-with-warning ()
+  (cask-test/with-bundle '((files "foo.el" "bar.el"))
+    (f-write-text "(next-line 1)" 'utf-8 "foo.el")
+    (cask-install bundle)
+    (should (cask-build bundle))))
+
+(ert-deftest cask-build-test/return-value-with-warning-with-warn-as-error ()
+  (cask-test/with-bundle '((files "foo.el" "bar.el"))
+    (f-write-text "(next-line 1)" 'utf-8 "foo.el")
+    (cask-install bundle)
+    (should-not (cask-build bundle :warn-as-error t))))
+
+(ert-deftest cask-build-test/return-value-with-error ()
+  (cask-test/with-bundle '((files "foo.el"))
+    (f-write-text "(require 'does-not-exit)" 'utf-8 "foo.el")
+    (cask-install bundle)
+    (should-not (cask-build bundle))))
+
+(ert-deftest cask-build-test/return-value-multiple-files ()
+  (cask-test/with-bundle '((files "foo.el" "bar.el"))
+    (f-write-text "(print \"Hello World!\")" 'utf-8 "foo.el")
+    (f-write-text "(require 'does-not-exit)" 'utf-8 "bar.el")
+    (cask-install bundle)
+    (should-not (cask-build bundle))))
+
 
 ;;;; cask-clean-elc
 


### PR DESCRIPTION
If any of the files contained a compiler error, exit with status code 1, otherwise 0.

Also add the option `--warn-as-error` that will consider compiler warnings as errors, which means if any of the files contained any warning, exit with status code 1.
