### PR TITLE
Fixes #252 add support for package pinning

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -815,7 +815,7 @@ url to the fetcher source."
     (-when-let (archive (plist-get args :archive))
       (if (not (boundp 'package-pinned-packages))
           (princ "Archive pinning is only supported with Emacs v24.4+.\n")
-          (do
+          (progn
               (setq package-pinned-packages
                     (add-to-list
                      'package-pinned-packages

--- a/cask.el
+++ b/cask.el
@@ -106,8 +106,10 @@ when fetcher is specified.
 
 `ref' The ref to use if fetcher.
 
-`branch' The branch to use if fetcher."
-  name version fetcher url files ref branch)
+`branch' The branch to use if fetcher.
+
+`archive' The archive to pin the dependency to."
+  name version fetcher url files ref branch archive)
 
 (cl-defstruct cask-source
   "Structure representing a package source.
@@ -792,6 +794,8 @@ ARGS is a plist with these optional arguments:
 
  `:branch' Fetcher branch to checkout.
 
+ `:archive' Pin package to archive.
+
 ARGS can also include any of the items in `cask-fetchers'.  The
 plist key is one of the items in the list and the value is the
 url to the fetcher source."
@@ -808,6 +812,12 @@ url to the fetcher source."
         (setf (cask-dependency-ref dependency) ref))
       (-when-let (branch (plist-get args :branch))
         (setf (cask-dependency-branch dependency) branch)))
+    (-when-let (archive (plist-get args :archive))
+      (setq package-pinned-packages
+            (add-to-list
+             'package-pinned-packages
+             `(,name . ,archive) package-pinned-packages))
+      (setf (cask-dependency-archive dependency) archive))
     (if (eq (plist-get args :scope) 'development)
         (push dependency (cask-bundle-development-dependencies bundle))
       (push dependency (cask-bundle-runtime-dependencies bundle)))))

--- a/cask.el
+++ b/cask.el
@@ -794,7 +794,7 @@ ARGS is a plist with these optional arguments:
 
  `:branch' Fetcher branch to checkout.
 
- `:archive' Pin package to archive.
+ `:archive' Pin package to archive. Only supported by Emacs v24.4+.
 
 ARGS can also include any of the items in `cask-fetchers'.  The
 plist key is one of the items in the list and the value is the
@@ -813,11 +813,14 @@ url to the fetcher source."
       (-when-let (branch (plist-get args :branch))
         (setf (cask-dependency-branch dependency) branch)))
     (-when-let (archive (plist-get args :archive))
-      (setq package-pinned-packages
-            (add-to-list
-             'package-pinned-packages
-             `(,name . ,archive) package-pinned-packages))
-      (setf (cask-dependency-archive dependency) archive))
+      (if (not (boundp 'package-pinned-packages))
+          (princ "Archive pinning is only supported with Emacs v24.4+.\n")
+          (do
+              (setq package-pinned-packages
+                    (add-to-list
+                     'package-pinned-packages
+                     `(,name . ,archive) package-pinned-packages))
+              (setf (cask-dependency-archive dependency) archive))))
     (if (eq (plist-get args :scope) 'development)
         (push dependency (cask-bundle-development-dependencies bundle))
       (push dependency (cask-bundle-runtime-dependencies bundle)))))

--- a/cask.el
+++ b/cask.el
@@ -816,10 +816,7 @@ url to the fetcher source."
     (-when-let (archive (plist-get args :archive))
       (unless (boundp 'package-pinned-packages)
         (signal 'cask-no-pinning nil))
-      (setq package-pinned-packages
-            (add-to-list
-             'package-pinned-packages
-             `(,name . ,archive) package-pinned-packages))
+      (add-to-list 'package-pinned-packages `(,name . ,archive))
       (setf (cask-dependency-archive dependency) archive))
     (if (eq (plist-get args :scope) 'development)
         (push dependency (cask-bundle-development-dependencies bundle))

--- a/doc/guide/dsl.rst
+++ b/doc/guide/dsl.rst
@@ -67,7 +67,7 @@ Dependencies
 ============
 
 .. function:: depends-on package-name &optional minimum-version
-              depends-on package-name :fetcher repourl &optional :ref hash :branch name :files patterns
+              depends-on package-name :fetcher repourl &optional :ref hash :branch name :files patterns :archive name
 
    Specify a dependency of this package.
 
@@ -89,6 +89,11 @@ Dependencies
    :var:`files` gives the files from the repository to include in the
    package, in the same format as :function:`files`.  If omitted, try to take
    the files from the :file:`Cask` file of the repository.
+
+   :var:`archive` pins the package to the given archive identified by `name`
+   by adding an entry to the Emacs variable ``package-pinned-packages``.
+   ``package-pinned-packages`` has been introduced in Emacs v24.4 therefore
+   the pinning feature is not supported by older version.
 
 .. function:: development &rest body
 

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -634,19 +634,16 @@
       (should (equal orig-load-path load-path)))))
 
 (ert-deftest cask-install-test/pin-archive ()
-  (let ((bound? (boundp 'package-pinned-packages)))
-    (setq package-pinned-packages nil)
+  (let ((package-pinned-packages nil))
     (cask-test/with-bundle
-     '((source localhost)
-       (depends-on "package-a" "0.0.1" :archive "localhost"))
-     (let ((archive (cask-dependency-archive
-                     (car (cask-bundle-runtime-dependencies bundle)))))
-       (cask-install bundle)
-       (should (equal archive "localhost"))
-       (should (equal package-pinned-packages
-                      '((package-a . "localhost"))))))
-    (unless bound?
-      (makunbound 'package-pinned-packages))))
+        '((source localhost)
+          (depends-on "package-a" "0.0.1" :archive "localhost"))
+      (let ((archive (cask-dependency-archive
+                      (car (cask-bundle-runtime-dependencies bundle)))))
+        (cask-install bundle)
+        (should (equal archive "localhost"))
+        (should (equal package-pinned-packages
+                       '((package-a . "localhost"))))))))
 
 (ert-deftest cask-install-test/pin-archive-no-package-pinned-packages ()
   (let ((bound? (boundp 'package-pinned-packages)))

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -634,17 +634,17 @@
       (should (equal orig-load-path load-path)))))
 
 (ert-deftest cask-install-test/pin-archive ()
-  (when (not (boundp 'package-pinned-packages))
-    (ert-skip
-     "`package-pinned-packages' is not defined, we need Emacs v24.4+ to test the pinning feature."))
-  (cask-test/with-bundle
-   '((source localhost)
-     (depends-on "package-a" "0.0.1" :archive "localhost"))
-   (let ((archive (cask-dependency-archive
-                   (car (cask-bundle-runtime-dependencies bundle)))))
-     (cask-install bundle)
-     (should (equal archive "localhost"))
-     (should (equal package-pinned-packages '((package-a . "localhost")))))))
+  (if  (not (boundp 'package-pinned-packages))
+    (princ "`package-pinned-packages' is not defined, we need Emacs v24.4+ to test the pinning feature.\n")
+    (cask-test/with-bundle
+     '((source localhost)
+       (depends-on "package-a" "0.0.1" :archive "localhost"))
+     (let ((archive (cask-dependency-archive
+                     (car (cask-bundle-runtime-dependencies bundle)))))
+       (cask-install bundle)
+       (should (equal archive "localhost"))
+       (should (equal package-pinned-packages
+                      '((package-a . "localhost"))))))))
 
 (ert-deftest cask-install-test/fetcher-git ()
   (cask-test/with-git-repo

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -646,7 +646,7 @@
        (should (equal package-pinned-packages
                       '((package-a . "localhost"))))))
     (unless bound?
-      (makunbound package-pinned-packages))))
+      (makunbound 'package-pinned-packages))))
 
 (ert-deftest cask-install-test/fetcher-git ()
   (cask-test/with-git-repo

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -634,15 +634,17 @@
       (should (equal orig-load-path load-path)))))
 
 (ert-deftest cask-install-test/pin-archive ()
+  (when (boundp 'package-pinned-packages)
+    (ert-skip
+     "`package-pinned-packages' is not defined, we need Emacs v24.4+ to test the pinning feature."))
   (cask-test/with-bundle
    '((source localhost)
      (depends-on "package-a" "0.0.1" :archive "localhost"))
    (let ((archive (cask-dependency-archive
                    (car (cask-bundle-runtime-dependencies bundle)))))
      (cask-install bundle)
-     (when (boundp 'package-pinned-packages)
-       (should (equal archive "localhost"))
-       (should (equal package-pinned-packages '((package-a . "localhost"))))))))
+     (should (equal archive "localhost"))
+     (should (equal package-pinned-packages '((package-a . "localhost")))))))
 
 (ert-deftest cask-install-test/fetcher-git ()
   (cask-test/with-git-repo

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -648,6 +648,22 @@
     (unless bound?
       (makunbound 'package-pinned-packages))))
 
+(ert-deftest cask-install-test/pin-archive-no-package-pinned-packages ()
+  (let ((bound? (boundp 'package-pinned-packages)))
+    (makunbound 'package-pinned-packages)
+    (should-error
+     (condition-case err
+         (progn
+           (cask--eval
+            (make-cask-bundle)
+            '((depends-on "package-a" "0.0.1" :archive "localhost")))
+           (when bound? (setq package-pinned-packages nil)))
+       (error
+        (signal (car err) (cdr err))))
+     :type 'cask-no-pinning)
+    (when bound?
+      (setq package-pinned-packages nil))))
+
 (ert-deftest cask-install-test/fetcher-git ()
   (cask-test/with-git-repo
    (cask-test/with-bundle

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -634,8 +634,8 @@
       (should (equal orig-load-path load-path)))))
 
 (ert-deftest cask-install-test/pin-archive ()
-  (if  (not (boundp 'package-pinned-packages))
-    (princ "`package-pinned-packages' is not defined, we need Emacs v24.4+ to test the pinning feature.\n")
+  (let ((bound? (boundp 'package-pinned-packages)))
+    (setq package-pinned-packages nil)
     (cask-test/with-bundle
      '((source localhost)
        (depends-on "package-a" "0.0.1" :archive "localhost"))
@@ -644,7 +644,9 @@
        (cask-install bundle)
        (should (equal archive "localhost"))
        (should (equal package-pinned-packages
-                      '((package-a . "localhost"))))))))
+                      '((package-a . "localhost"))))))
+    (unless bound?
+      (makunbound package-pinned-packages))))
 
 (ert-deftest cask-install-test/fetcher-git ()
   (cask-test/with-git-repo

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -646,20 +646,17 @@
                        '((package-a . "localhost"))))))))
 
 (ert-deftest cask-install-test/pin-archive-no-package-pinned-packages ()
-  (let ((bound? (boundp 'package-pinned-packages)))
+  (let ((package-pinned-packages nil))
     (makunbound 'package-pinned-packages)
     (should-error
      (condition-case err
          (progn
            (cask--eval
             (make-cask-bundle)
-            '((depends-on "package-a" "0.0.1" :archive "localhost")))
-           (when bound? (setq package-pinned-packages nil)))
+            '((depends-on "package-a" "0.0.1" :archive "localhost"))))
        (error
         (signal (car err) (cdr err))))
-     :type 'cask-no-pinning)
-    (when bound?
-      (setq package-pinned-packages nil))))
+     :type 'cask-no-pinning)))
 
 (ert-deftest cask-install-test/fetcher-git ()
   (cask-test/with-git-repo

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -640,8 +640,9 @@
    (let ((archive (cask-dependency-archive
                    (car (cask-bundle-runtime-dependencies bundle)))))
      (cask-install bundle)
-     (should (equal archive "localhost"))
-     (should (equal package-pinned-packages '((package-a . "localhost")))))))
+     (when (boundp 'package-pinned-packages)
+       (should (equal archive "localhost"))
+       (should (equal package-pinned-packages '((package-a . "localhost"))))))))
 
 (ert-deftest cask-install-test/fetcher-git ()
   (cask-test/with-git-repo

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -633,6 +633,16 @@
       (cask-install bundle)
       (should (equal orig-load-path load-path)))))
 
+(ert-deftest cask-install-test/pin-archive ()
+  (cask-test/with-bundle
+   '((source localhost)
+     (depends-on "package-a" "0.0.1" :archive "localhost"))
+   (let ((archive (cask-dependency-archive
+                   (car (cask-bundle-runtime-dependencies bundle)))))
+     (cask-install bundle)
+     (should (equal archive "localhost"))
+     (should (equal package-pinned-packages '((package-a . "localhost")))))))
+
 (ert-deftest cask-install-test/fetcher-git ()
   (cask-test/with-git-repo
    (cask-test/with-bundle

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -634,7 +634,7 @@
       (should (equal orig-load-path load-path)))))
 
 (ert-deftest cask-install-test/pin-archive ()
-  (when (boundp 'package-pinned-packages)
+  (when (not (boundp 'package-pinned-packages))
     (ert-skip
      "`package-pinned-packages' is not defined, we need Emacs v24.4+ to test the pinning feature."))
   (cask-test/with-bundle


### PR DESCRIPTION
Fixes #252

I added an `archive` attribute to the `cask-dependency` cl-struct.
I read it from a `:archive "melpa-stable"` specified in the `(depends-on )` form, set the field in the dependency cl-struct and update `package-pinned-packages`.

Example:

```
(depends-on "f" :archive "melpa-stable")
```

Note: `package-pinned-packages` is from emacs v24.4 if C-h v is correct.

~~Do not merge, I still need to update the documentation and write some tests.~~
Btw I don't write emacs lisp often, if someone could proofread that would be great.
