### PR TITLE
Simplify the cask install directory.

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -682,7 +682,10 @@ If BUNDLE is not a package, the error `cask-not-a-package' is signaled."
 
 (defun cask-elpa-path (bundle)
   "Return full path to BUNDLE elpa directory."
-  (f-expand (format ".cask/%s/elpa" emacs-version) (cask-bundle-path bundle)))
+  (f-expand (format ".cask/%s.%s/elpa"
+                    emacs-major-version
+                    emacs-minor-version)
+            (cask-bundle-path bundle)))
 
 (defun cask-runtime-dependencies (bundle &optional deep)
   "Return BUNDLE's runtime dependencies.

--- a/features/step-definitions/cask-steps.el
+++ b/features/step-definitions/cask-steps.el
@@ -39,7 +39,10 @@
 (defun cask-test/template (command)
   "Return COMMAND with placeholders replaced with values."
   (->> command
-    (s-replace "{{EMACS-VERSION}}" emacs-version)
+    (s-replace "{{EMACS-VERSION}}"
+               (format "%s.%s"
+                       emacs-major-version
+                       emacs-minor-version))
     (s-replace "{{EMACS}}" (executable-find (or (getenv "EMACS") "emacs")))))
 
 (Given "^this Cask file:$"
@@ -88,14 +91,21 @@
 (Then "^I should see usage information$"
   (lambda ()
     (should (s-contains? "USAGE: cask [COMMAND] [OPTIONS]" cask-test/stdout))))
-
 (Then "^package \"\\([^\"]+\\)\" should be installed$"
   (lambda (package)
-    (should (f-dir? (f-join cask-test/sandbox-path ".cask" emacs-version "elpa" package)))))
+    (should (f-dir? (f-join cask-test/sandbox-path ".cask"
+                            (format "%s.%s"
+                                    emacs-major-version
+                                    emacs-minor-version)
+                            "elpa" package)))))
 
 (Then "^package \"\\([^\"]+\\)\" should not be installed$"
   (lambda (package)
-    (should-not (f-dir? (f-join cask-test/sandbox-path ".cask" emacs-version "elpa" package)))))
+    (should-not (f-dir? (f-join cask-test/sandbox-path ".cask"
+                                (format "%s.%s"
+                                        emacs-major-version
+                                        emacs-minor-version)
+                                "elpa" package)))))
 
 (provide 'cask-steps)
 

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -397,7 +397,10 @@
 (ert-deftest cask-elpa-path-test ()
   (cask-test/with-bundle nil
     (let ((actual (cask-elpa-path bundle))
-          (expected (f-join cask-test/sandbox-path ".cask" emacs-version "elpa")))
+          (expected (f-join cask-test/sandbox-path
+                            (format ".cask/%s.%s/elpa"
+                                    emacs-major-version
+                                    emacs-minor-version))))
       (should (string= actual expected)))))
 
 


### PR DESCRIPTION
Previously cask creates a new directory for every version string change,
which, for those running from a development build means most rebuilds.
Now, just use the emacs major and minor version.