### PR TITLE
Use byte-strings to compare environment variables

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -263,10 +263,10 @@ def inside_emacs_24():
     ## are we inside Emacs at all
     return (b'INSIDE_EMACS' in ENVB and
             ## M-x compile in Emacs-24 sets INSIDE_EMACS to exactly 't'
-            (ENVB.get(b'INSIDE_EMACS') == 't' or
+            (ENVB.get(b'INSIDE_EMACS') == b't' or
              ## while M-x shell sets it to a string, starting with the
              ## version number
-             ENVB.get(b'INSIDE_EMACS').startswith('24')))
+             ENVB.get(b'INSIDE_EMACS').startswith(b'24')))
 
 def get_emacs_from_env():
     """Get the Emacs executable as specified by the environment.


### PR DESCRIPTION
75b6148 explicitly use byte-string environment variables in python 3,
and fails when tries to compare it with plain strings. 


```shell
# Python 3
~ $ INSIDE_EMACS=t python3 -c "import os; print(os.environb[b'INSIDE_EMACS'] == 't')"
False
~ $ INSIDE_EMACS=t python3 -c "import os; print(os.environb[b'INSIDE_EMACS'] == b't')"
True
# Python 2
~ $ INSIDE_EMACS=t python2 -c "import os; print(os.environ[b'INSIDE_EMACS'] == 't')"
True
~ $ INSIDE_EMACS=t python2 -c "import os; print(os.environ[b'INSIDE_EMACS'] == b't')"
True
```