### PR TITLE
Simplify the cask bootstrap directory.

### DIFF
--- a/cask-bootstrap.el
+++ b/cask-bootstrap.el
@@ -30,9 +30,14 @@
 (eval-when-compile
   (defvar cask-directory))
 
+(defconst cask-bootstrap-emacs-version
+  (format "%s.%s"
+          emacs-major-version
+          emacs-minor-version))
+
 (defconst cask-bootstrap-dir
   (expand-file-name
-   (locate-user-emacs-file (format ".cask/%s/bootstrap" emacs-version)))
+   (locate-user-emacs-file (format ".cask/%s/bootstrap" cask-bootstrap-emacs-version)))
   "Path to Cask bootstrap directory.")
 
 (defconst cask-bootstrap-packages

--- a/cask.el
+++ b/cask.el
@@ -682,9 +682,8 @@ If BUNDLE is not a package, the error `cask-not-a-package' is signaled."
 
 (defun cask-elpa-path (bundle)
   "Return full path to BUNDLE elpa directory."
-  (f-expand (format ".cask/%s.%s/elpa"
-                    emacs-major-version
-                    emacs-minor-version)
+  (f-expand (format ".cask/%s/elpa"
+                    cask-bootstrap-emacs-version)
             (cask-bundle-path bundle)))
 
 (defun cask-runtime-dependencies (bundle &optional deep)


### PR DESCRIPTION
Should have done this with the last commit, but hadn't realised that the full version string was used here also.


