### PR TITLE
Check equality using string comparison

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -561,7 +561,7 @@ This function return a `cask-bundle' object."
           (-snoc (--map (list (cask-dependency-name it) t)
                         (cask--runtime-dependencies bundle))
                  'all)))
-    (when (f-same? (epl-package-dir) (epl-default-package-dir))
+    (when (equal (epl-package-dir) (epl-default-package-dir))
       (cask--use-environment bundle :activate t))
     bundle))
 

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -500,7 +500,7 @@
 ;;;; cask-file
 
 (ert-deftest cask-file-test ()
-  (cask-test/with-bundle nil
+  (cask-test/with-bundle 'empty
     (should (f-same? (cask-file bundle) (f-expand "Cask" cask-test/sandbox-path)))))
 
 


### PR DESCRIPTION
The f-same? function changed and required the files to exist to be same, but that might not be the case here. Use string equality check instead.