### PR TITLE
Use subprocess.call instead of os.execvp for all commands but cask exec

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -345,13 +345,13 @@ def exec_cask(arguments):
     Find the Emacs to use for Cask, and run the Cask CLI with the given
     ``arguments``.
 
-    This function replaces the current process.  It does **not** return.
+    This function exits with Emacs' return code.  It does **not** return.
 
     """
     emacs = get_cask_emacs()
     cli = os.path.join(CASK_DIRECTORY, 'cask-cli.el')
     command = [emacs, '-Q', '--script', cli, '--'] + arguments
-    os.execvp(command[0], command)
+    sys.exit(subprocess.call(command))
 
 
 def exit_error(error):


### PR DESCRIPTION
This shouldn't make a significant difference on GNU/Linux or macOS, but
it makes Cask much nicer to use on Windows (http://bugs.python.org/issue9148).

Alternatively, I could make this platform-dependent (subprocess.call on Linux, execvp everywhere else).