### PR TITLE
add package-descriptor directive

### DIFF
--- a/cask-bootstrap.el
+++ b/cask-bootstrap.el
@@ -41,7 +41,7 @@
   "Path to Cask bootstrap directory.")
 
 (defconst cask-bootstrap-packages
-  '(s dash f commander git epl shut-up cl-lib package-build)
+  '(s dash f commander git epl shut-up cl-lib package-build eieio)
   "List of bootstrap packages required by this file.")
 
 (unless (require 'package nil :noerror)

--- a/cask.el
+++ b/cask.el
@@ -393,13 +393,17 @@ SCOPE may be nil or 'development."
                      (cask--show-package-error err filename)))))
              (cask--from-epl-package bundle package))))
         (package-descriptor
-         (cl-destructuring-bind (_ filename) form
-           (let ((package
-                  (condition-case err
+         (cl-destructuring-bind (_ &optional filename) form
+           (let* ((descriptor-filename
+                   (or filename (let ((pkg-files (f-glob "*-pkg.el" (s-chop-suffix "/" (cask-bundle-path bundle)))))
+                                  (if (car pkg-files) (f-filename (car pkg-files))
+                                    (error "No -pkg.el file found for package descriptor")))))
+                  (package
+                   (condition-case err
                       (epl-package-from-descriptor-file
-                       (f-expand filename (cask-bundle-path bundle)))
+                       (f-expand descriptor-filename (cask-bundle-path bundle)))
                     (epl-invalid-package
-                     (cask--show-package-error err filename)))))
+                     (cask--show-package-error err descriptor-filename)))))
              (cask--from-epl-package bundle package))))
         (depends-on
          (cl-destructuring-bind (_ name &rest args) form

--- a/cask.el
+++ b/cask.el
@@ -392,6 +392,15 @@ SCOPE may be nil or 'development."
                     (epl-invalid-package
                      (cask--show-package-error err filename)))))
              (cask--from-epl-package bundle package))))
+        (package-descriptor
+         (cl-destructuring-bind (_ filename) form
+           (let ((package
+                  (condition-case err
+                      (epl-package-from-descriptor-file
+                       (f-expand filename (cask-bundle-path bundle)))
+                    (epl-invalid-package
+                     (cask--show-package-error err filename)))))
+             (cask--from-epl-package bundle package))))
         (depends-on
          (cl-destructuring-bind (_ name &rest args) form
            (when (stringp (car args))

--- a/doc/guide/dsl.rst
+++ b/doc/guide/dsl.rst
@@ -38,6 +38,16 @@ Package metadata
    library headers of :var:`file`.  See :infonode:`(elisp)Library Headers` for
    details about library headers
 
+.. function:: package-descriptor file
+
+   Declare all package metadata directly by specifiying a package descriptor
+   contained in file with name given by :var:`file`
+
+   See `Multi-file Packages`_ for examples on defining packages with the
+   :function:`define-package` function.
+
+   .. _Multi-file Packages: https://www.gnu.org/software/emacs/manual/html_node/elisp/Multi_002dfile-Packages.html
+
 Package contents
 ================
 

--- a/features/package-descriptor.feature
+++ b/features/package-descriptor.feature
@@ -16,17 +16,26 @@ Scenario: When no filename is specified.
   (source "localhost" "http://127.0.0.1:9191/packages/")
   (package-descriptor)
   """
-  And a file named "superpackage-pkg.el"
-    """
+  When I create a file called "superpackage-pkg.el" with content:
+  """
     (define-package "super-package" "1.2.3" "A Package that is really super."
      '((package-a "0.0.1")))
-    """
-
-  When I run cask "build"
-  Then it builds a package named "superpackage"
+  """
 
   When I run cask "install"
-  Then package "package-a" should be installed
+  Then package "package-a-0.0.1" should be installed
+
+Scenario: When no filename is specified and there is no -pkg.el file.
+  Given this Cask file:
+  """
+  (package-descriptor)
+  """
+
+  When I run cask "install"
+  Then I should see command error:
+  """
+  No -pkg.el file found for package descriptor
+  """
 
 Scenario: When a package descriptor file is explicitly specified
   Given this Cask file:
@@ -34,14 +43,23 @@ Scenario: When a package descriptor file is explicitly specified
   (source "localhost" "http://127.0.0.1:9191/packages/")
   (package-descriptor "unconventionally-named.el")
   """
-  And this file named "unconventionally-named.el"
+  When I create a file called "unconventionally-named.el" with content:
   """
   (define-package "super-package" "1.2.3" "A Package that is really super."
     '((package-a "0.0.1")))
   """
 
-  When I run cask "build"
-  Then it builds a package named "superpackage"
+  When I run cask "install"
+  Then package "package-a-0.0.1" should be installed
+
+Scenario: When a package descriptor file is explicitly specified but the file does not exist.
+  Given this Cask file:
+  """
+  (package-descriptor "unconventionally-named.el")
+  """
 
   When I run cask "install"
-  Then package "package-a" should be installed
+  Then I should see command error:
+  """
+  No such file or directory
+  """

--- a/features/package-descriptor.feature
+++ b/features/package-descriptor.feature
@@ -1,0 +1,47 @@
+Feature: Specify a package descriptor directly.
+
+Most packages will use the dependencies listend in the main package file's
+`Package-Requires` directive embedded in the magic comments
+section. The dependencies listed in this fashion can only be
+enumerated on a single line however, and so this can get quite out of
+hand for packages that have a large list of dependencies.
+
+In these cases, cask allows you to explicitly enumerate all of the
+dependencies directly in elisp using the package descriptor and the
+`define-package` function.
+
+Scenario: When no filename is specified.
+  Given this Cask file:
+  """
+  (source "localhost" "http://127.0.0.1:9191/packages/")
+  (package-descriptor)
+  """
+  And a file named "superpackage-pkg.el"
+    """
+    (define-package "super-package" "1.2.3" "A Package that is really super."
+     '((package-a "0.0.1")))
+    """
+
+  When I run cask "build"
+  Then it builds a package named "superpackage"
+
+  When I run cask "install"
+  Then package "package-a" should be installed
+
+Scenario: When a package descriptor file is explicitly specified
+  Given this Cask file:
+  """
+  (source "localhost" "http://127.0.0.1:9191/packages/")
+  (package-descriptor "unconventionally-named.el")
+  """
+  And this file named "unconventionally-named.el"
+  """
+  (define-package "super-package" "1.2.3" "A Package that is really super."
+    '((package-a "0.0.1")))
+  """
+
+  When I run cask "build"
+  Then it builds a package named "superpackage"
+
+  When I run cask "install"
+  Then package "package-a" should be installed

--- a/features/package-descriptor.feature
+++ b/features/package-descriptor.feature
@@ -61,5 +61,5 @@ Scenario: When a package descriptor file is explicitly specified but the file do
   When I run cask "install"
   Then I should see command error:
   """
-  No such file or directory
+  such file or directory
   """


### PR DESCRIPTION
Sometimes you want to just explicitly enumerate package metadata yourself in a `-pkg.el` that contains everything from the name, to the dependencies.

This allows Cask to read package metadata from a pre-existing package descriptor by adding the `package-descriptor` directive. This directive functions in a very similar fashion to the `package-file` directive. For example, if you have a package descriptor in `my-package-pkg.el"`, that looks like:

```elisp
(define-package "my-package" "1.0.0" "a great package"
  '((foo "2.8.0")
    (bar "0.7.0")
    (bazz "0.13.0"))
  :keywords '("awesome" "possum"))
```

You can have Cask use it by including this line in your `Cask` file.

```elisp
(package-descriptor "my-package-pkg.el")
````
resolves #381 

## TODOS

- [x] Find out where is the appropriate place to test
- [x] Customize any errors where appropriate
- [x] Add documentation