### PR TITLE
cask init: autofill the package-file value

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -632,7 +632,7 @@ configuration template is used."
     ;; If there's only a single .el file, use that as the package-file.
     (when dev-mode
       (let* ((files (f-files (cask-path bundle)))
-             (el-files (--filter (s-ends-with? ".el" it) files))
+             (el-files (--filter (f-ext? it "el") files))
              (package-file (if (equal (length el-files) 1)
                                (f-filename (-first-item el-files))
                              "TODO")))

--- a/cask.el
+++ b/cask.el
@@ -629,6 +629,14 @@ configuration template is used."
   (let ((cask-file (cask-file bundle))
         (init-content
          (cask--template-get (if dev-mode "init-dev.tpl" "init.tpl"))))
+    ;; If there's only a single .el file, use that as the package-file.
+    (when dev-mode
+      (let* ((files (f-files (cask-path bundle)))
+             (el-files (--filter (s-ends-with? ".el" it) files))
+             (package-file (if (equal (length el-files) 1)
+                               (f-filename (-first-item el-files))
+                             "TODO")))
+        (setq init-content (format init-content package-file))))
     (if (f-file? cask-file)
         (error "Cask-file already exists")
       (f-write-text init-content 'utf-8 cask-file))))

--- a/templates/init-dev.tpl
+++ b/templates/init-dev.tpl
@@ -1,7 +1,7 @@
 (source gnu)
 (source melpa)
 
-(package-file "TODO")
+(package-file "%s")
 
 (development
  (depends-on "f")

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -512,6 +512,35 @@
     (cask-caskify bundle)
     (should (f-file? (f-expand "Cask" cask-test/sandbox-path)))))
 
+(ert-deftest cask-caskify-dev ()
+  (cask-test/with-bundle nil
+    (should-not (f-file? (f-expand "Cask" cask-test/sandbox-path)))
+    (cask-caskify bundle t)
+    (should (f-file? (f-expand "Cask" cask-test/sandbox-path)))
+    (should (s-matches? "^\(package-file \"TODO\"\)$"
+                        (f-read-text (f-expand "Cask" cask-test/sandbox-path))))))
+
+(ert-deftest cask-caskify-dev-single-el-file ()
+  (cask-test/with-bundle nil
+    (let ((main-package-file "foo.el"))
+      (should-not (f-file? (f-expand "Cask" cask-test/sandbox-path)))
+      (f-touch (f-expand main-package-file cask-test/sandbox-path))
+      (f-touch (f-expand "bar" cask-test/sandbox-path))
+      (cask-caskify bundle t)
+      (should (f-file? (f-expand "Cask" cask-test/sandbox-path)))
+      (should (s-matches? (format "^\(package-file \"%s\"\)$" main-package-file)
+                          (f-read-text (f-expand "Cask" cask-test/sandbox-path)))))))
+
+(ert-deftest cask-caskify-dev-multi-el-file ()
+  (cask-test/with-bundle nil
+    (should-not (f-file? (f-expand "Cask" cask-test/sandbox-path)))
+    (f-touch (f-expand "foo.el" cask-test/sandbox-path))
+    (f-touch (f-expand "bar.el" cask-test/sandbox-path))
+    (cask-caskify bundle t)
+    (should (f-file? (f-expand "Cask" cask-test/sandbox-path)))
+    (should (s-matches? "^\(package-file \"TODO\"\)$"
+                        (f-read-text (f-expand "Cask" cask-test/sandbox-path))))))
+
 
 ;;;; cask-update
 


### PR DESCRIPTION
If we're in a directory that only contains a single foo.el, that's
probably the value we want for package-file.

Before:

    (package-file "TODO")

After:

    (package-file "foo.el")

If it's ambiguous, use the previous behaviour.