### PR TITLE
Do not show the optional arg of --help in usage

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -399,7 +399,7 @@ Commands:
  (option "--no-proxy" cask-cli/cask-no-proxy)
 
  (option "--version" cask-cli/cask-version)
- (option "-h [command], --help [command]" cask-cli/help)
+ (option "-h, --help" "Display usage information" cask-cli/help)
  (option "--dev" cask-cli/dev)
  (option "--debug" cask-cli/debug)
  (option "--path <path>" cask-cli/set-path)


### PR DESCRIPTION
The --help option should only be used to display the usage
information.  This is the standard way to define command line options.