### PR TITLE
Use only emacs-version in cask-bootstrap-emacs-version

### DIFF
--- a/cask-bootstrap.el
+++ b/cask-bootstrap.el
@@ -31,9 +31,9 @@
   (defvar cask-directory))
 
 (defconst cask-bootstrap-emacs-version
-  (format "%s.%s"
-          emacs-major-version
-          emacs-minor-version))
+  (format "%s"
+          emacs-version))
+
 
 (defconst cask-bootstrap-dir
   (expand-file-name

--- a/features/step-definitions/cask-steps.el
+++ b/features/step-definitions/cask-steps.el
@@ -40,9 +40,8 @@
   "Return COMMAND with placeholders replaced with values."
   (->> command
     (s-replace "{{EMACS-VERSION}}"
-               (format "%s.%s"
-                       emacs-major-version
-                       emacs-minor-version))
+               (format "%s"
+                       emacs-version))
     (s-replace "{{EMACS}}" (executable-find (or (getenv "EMACS") "emacs")))))
 
 (Given "^this Cask file:$"
@@ -94,17 +93,15 @@
 (Then "^package \"\\([^\"]+\\)\" should be installed$"
   (lambda (package)
     (should (f-dir? (f-join cask-test/sandbox-path ".cask"
-                            (format "%s.%s"
-                                    emacs-major-version
-                                    emacs-minor-version)
+                            (format "%s"
+                                    emacs-version)
                             "elpa" package)))))
 
 (Then "^package \"\\([^\"]+\\)\" should not be installed$"
   (lambda (package)
     (should-not (f-dir? (f-join cask-test/sandbox-path ".cask"
-                                (format "%s.%s"
-                                        emacs-major-version
-                                        emacs-minor-version)
+                                (format "%s"
+                                        emacs-version)
                                 "elpa" package)))))
 
 (provide 'cask-steps)

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -398,9 +398,8 @@
   (cask-test/with-bundle nil
     (let ((actual (cask-elpa-path bundle))
           (expected (f-join cask-test/sandbox-path
-                            (format ".cask/%s.%s/elpa"
-                                    emacs-major-version
-                                    emacs-minor-version))))
+                            (format ".cask/%s/elpa"
+                                    emacs-version))))
       (should (string= actual expected)))))
 
 


### PR DESCRIPTION
- GNU Emacs 25.2.1
- Mac OSX 10.12.4

Emacs cannot load packages because current cask downloads packages as "25.2".
It is because cask downloads Emacs packages emacs-major-version + emacs-minor-version as "25.2".