### PR TITLE
If /usr/bin is at the front of $PATH, strip it -- attempt 2

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -379,6 +379,14 @@ def main():
 
     """
     try:
+        # Special handling for emacs on travis with evm and buggy pyenv, see
+        # cask issue #399.
+        if ENVB.get(b'TRAVIS', b'') == b'true':
+            paths = ENVB[b'PATH'].split(b':')
+            if len(paths) > 0 and paths[0] == b'/usr/bin':
+                ENVB[b'PATH'] = ':'.join(paths[1:])
+
+
         if sys.version_info[:2] < (2, 6):
             exit_error(
                 'Python 2.6 required, yours is {0.major}.{0.minor}'.format(

--- a/features/exec.feature
+++ b/features/exec.feature
@@ -64,3 +64,22 @@ Feature: Exec
       cask exec: error: Failed to execute does-not-exist: [Errno 2] No such file or directory
       Did you run cask install?
       """
+
+  Scenario: With Travis' pyenv prepending /usr/bin to path, remove the first instance
+    Given this Cask file:
+      """
+      """
+    When I set environment variable "TRAVIS" to "true"
+    When "/usr/bin" is prepended to $PATH
+    When I run cask "exec sh -c 'echo $PATH'"
+    Then I should not see command output matching "^/usr/bin:"
+    Then I should see command output matching ":/usr/bin:"
+
+  Scenario: With a path starting with /usr/bin, but not on Travis
+    Given this Cask file:
+      """
+      """
+    When I set environment variable "TRAVIS" to "blah"
+    When "/usr/bin" is prepended to $PATH
+    When I run cask "exec sh -c 'echo $PATH'"
+    Then I should see command output matching "^/usr/bin:"

--- a/features/step-definitions/cask-steps.el
+++ b/features/step-definitions/cask-steps.el
@@ -72,6 +72,14 @@
                 (t
                  (setq cask-test/stderr content))))))))
 
+(When "^\"\\([^\"]+\\)\" is prepended to $PATH$"
+  (lambda (path)
+    (setenv "PATH" (s-concat path ":" (getenv "PATH")))))
+
+(When "I set environment variable \"\\([^\"]+\\)\" to \"\\([^\"]+\\)\""
+  (lambda (var value)
+    (setenv var value)))
+
 (Then "^I should see command error:$"
   (lambda (output)
     (should (s-contains? output cask-test/stderr))))
@@ -80,6 +88,10 @@
   (lambda (output)
     (should (s-contains? output cask-test/stdout))))
 
+(Then "^I should see command output matching \"\\([^\"]+\\)\"$"
+  (lambda (regex)
+    (should (s-matches? regex cask-test/stdout))))
+
 (Then "^I should not see command error:$"
   (lambda (output)
     (should-not (s-contains? output cask-test/stderr))))
@@ -87,6 +99,10 @@
 (Then "^I should not see command output:$"
   (lambda (output)
     (should-not (s-contains? output cask-test/stdout))))
+
+(Then "^I should not see command output matching \"\\(.*\\)\"$"
+  (lambda (regex)
+    (should-not (s-matches? regex cask-test/stdout))))
 
 (Then "^I should see usage information$"
   (lambda ()

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -52,10 +52,17 @@
 (defvar cask-test/stderr)
 (defvar cask-test/stdout)
 
+(defvar cask-initial-$PATH)
+(defvar cask-initial-$TRAVIS)
+
 (add-to-list 'load-path cask-test/root-path)
 
 (unless (require 'ert nil t)
   (require 'ert (f-expand "ert" cask-test/vendor-path)))
+
+(Setup
+ (setq cask-initial-$PATH (getenv "PATH"))
+ (setq cask-initial-$TRAVIS (getenv "TRAVIS")))
 
 (Before
  (setq cask-test/stderr "")
@@ -63,7 +70,10 @@
 
  (when (f-dir? cask-test/sandbox-path)
    (f-delete cask-test/sandbox-path 'force))
- (f-mkdir cask-test/sandbox-path))
+ (f-mkdir cask-test/sandbox-path)
+
+ (setenv "PATH" cask-initial-$PATH)
+ (setenv "TRAVIS" cask-initial-$TRAVIS))
 
 (Fail
  (-when-let (stdout (s-presence cask-test/stdout))


### PR DESCRIPTION
This is a second attempt at fixing this issue, the first one didn't work in some cases so I rolled it back. This time I managed to test my changes on Travis (by messing with the bootstrap process), and it does pick the correct emacs version as you can see [here](https://travis-ci.org/davidshepherd7/electric-operator/jobs/288197732).

The only thing I've changed from the previous attempt is that the PATH modifications are now in `main` instead of only in `exec_command` (which isn't always used). So now the path is fixed in everything that cask does instead of only when using `cask exec ...` or `cask emacs ...`.


---------------------------------------------------------------------------------------------------------

This is a workaround for a bug in pyenv which is affecting Travis
builds. pyenv is currently adding `/usr/bin` to the front of $PATH for
anything run through python. This screws up emacs version management
with evm which relies on the evm bin directory being earlier in the path
than any other directory containing emacs binaries.

Fixes #399.