### PR TITLE
Use private package-build--package

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -339,7 +339,7 @@ This function returns the path to the package file."
         (package-build-working-dir cask-tmp-checkout-path)
         (package-build-archive-dir cask-tmp-packages-path) )
     (let ((version (package-build--checkout rcp)))
-      (package-build-package rcp version)
+      (package-build--package rcp version)
       (let ((pattern (format "%s-%s.*" name version)))
         (--first (s-match ".*\\.\\(tar\\|el\\)" it)
                  (f-glob pattern cask-tmp-packages-path))))))
@@ -984,7 +984,7 @@ a directory specified by `cask-dist-path' in the BUNDLE path."
                   :dir path))
             (package-build-working-dir path)
             (package-build-archive-dir target-dir))
-        (package-build-package rcp version)))))
+        (package-build--package rcp version)))))
 
 (provide 'cask)
 


### PR DESCRIPTION
This fixes issue #426.
`package-build-package` was renamed to private `package-build--package`.
Using the private function was recommended in https://github.com/melpa/package-build/issues/20 as a quick fix and to work with them to create a reasonable public API that cask can use.

Thanks