### PR TITLE
Fix a few typos

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -315,7 +315,7 @@ Commands:
   (cask-package (cask-cli--bundle) target-dir))
 
 (defun cask-cli/emacs ()
-  "Execute emacs with the appropriate environmment.")
+  "Execute emacs with the appropriate environment.")
 
 
 ;;;; Options

--- a/doc/dev/contributing.rst
+++ b/doc/dev/contributing.rst
@@ -4,7 +4,7 @@
 
 This document provides guidelines and information on contributing to Cask.
 
-Cask is on Github_, and a discussion group is available at
+Cask is on GitHub_, and a discussion group is available at
 https://groups.google.com/forum/#!forum/cask-dev.
 
 .. _github: https://github.com/cask/cask

--- a/doc/guide/dsl.rst
+++ b/doc/guide/dsl.rst
@@ -34,13 +34,13 @@ Package metadata
 
    The package name will be the name of the given :var:`file`, sans directory
    and extension.  The description is taken from the very first line of
-   :var:`file`.  The version and the runtime dependencies are taken from the
+   :var:`file`.  The version and the run-time dependencies are taken from the
    library headers of :var:`file`.  See :infonode:`(elisp)Library Headers` for
    details about library headers
 
 .. function:: package-descriptor file
 
-   Declare all package metadata directly by specifiying a package descriptor
+   Declare all package metadata directly by specifying a package descriptor
    contained in file with name given by :var:`file`
 
    See `Multi-file Packages`_ for examples on defining packages with the

--- a/doc/guide/usage.rst
+++ b/doc/guide/usage.rst
@@ -49,7 +49,7 @@ it.
 Finding Emacs
 -------------
 
-By default, packages are installed for the default Emacs, i.e. the one behind
+By default, packages are installed for the default Emacs, i.e., the one behind
 the `emacs` command.  To pick a different Emacs, set the environment variable
 :envvar:`EMACS` to the command name or executable path of the Emacs to use:
 
@@ -107,7 +107,7 @@ cask emacs
    cask [GLOBAL-OPTIONS] emacs [ARGUMENTS ...]
 
 Execute `emacs` with the given :var:`arguments`, with the appropriate
-environmment (see :ref:`cask exec`). The Emacs executable is that which cask
+environment (see :ref:`cask exec`). The Emacs executable is that which cask
 would normally run in (see :ref:`finding_emacs`).
 
 
@@ -198,7 +198,7 @@ cask list
 
    cask [GLOBAL-OPTIONS] list
 
-List all runtime and development dependencies.
+List all run-time and development dependencies.
 
 .. _cask load-path:
 


### PR DESCRIPTION
Just fixed a few typos I noticed when using `Cask`.