### PR TITLE
Add package executable files to exec-path

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -711,6 +711,7 @@ If BUNDLE is not a package, the error `cask-not-a-package' is signaled."
   "Return Emacs `exec-path' (including BUNDLE dependencies)."
   (cask--with-environment bundle
     (append
+     (-map 'expand-file-name (-uniq (-map 'f-parent (-filter 'f-executable-p (cask-files bundle)))))
      (-select
       'f-dir?
       (-map

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -442,6 +442,16 @@
     (let ((path (f-join (cask-elpa-path bundle) "package-e-0.0.1" "bin")))
       (should (equal (cons path exec-path) (cask-exec-path bundle))))))
 
+(ert-deftest cask-exec-path-test/local-executable-files ()
+  (cask-test/with-bundle
+      '((source localhost)
+        (files "bin/executable"))
+    (f-mkdir "bin")
+    (f-touch "bin/executable")
+    (chmod "bin/executable" 755)
+    (let ((path (f-join (cask-path bundle) "bin/")))
+      (should (equal (cons path exec-path) (cask-exec-path bundle))))))
+
 
 ;;;; cask-load-path
 


### PR DESCRIPTION
Fixes #432

It is sometimes convenient to create executable scripts in the package to do routine tasks.  It is often useful to run these inside the proper environment that `cask exec` provides.

This patch adds all the directories from `cask files` which contain executable files to the `exec-path`.