### PR TITLE
Automatically initialize elpa dir when linking

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -515,18 +515,49 @@ returns an `epl-package' object."
                    package-function))))))
      dependencies))))
 
+(defun cask--dependency-to-epl-package (dependency)
+  "Convert cask DEPENDENCY to `epl-package'."
+  (epl-package-create
+   :name (cask-dependency-name dependency)
+   :description
+    (if (fboundp 'package-desc-name)
+        (package-desc-create
+         :name (cask-dependency-name dependency)
+         :version (version-to-list (or (cask-dependency-version dependency) "0"))
+         :reqs nil)
+      (vector (version-to-list (or (cask-dependency-version dependency) "0")) nil ""))))
+
+(defun cask--find-package (bundle name)
+  "In BUNDLE, find package NAME.
+
+Return any package which can be installed from an archive or one
+which is linked locally and thus also available or one which will
+be fetched from vcs."
+  (or (cask--find-available-package name)
+      (when (cask-linked-p bundle name)
+        (let ((link-bundle (cask-setup (cask-dependency-path bundle name))))
+          (epl-package-from-descriptor-file
+           (cask-define-package-file link-bundle))))
+      (-when-let (dep (cask-find-dependency bundle name))
+        (when (cask-dependency-fetcher dep)
+          (cask--dependency-to-epl-package dep)))))
+
 (defun cask--runtime-dependencies (bundle &optional deep)
   "Return runtime dependencies for BUNDLE, optionally DEEP."
   (let ((dependencies (cask-bundle-runtime-dependencies bundle)))
     (if deep
-        (cask--compute-dependencies dependencies 'cask--find-available-package)
+        (cask--compute-dependencies
+         dependencies
+         (lambda (name) (cask--find-package bundle name)))
       dependencies)))
 
 (defun cask--development-dependencies (bundle &optional deep)
   "Return development dependencies for BUNDLE, optionally DEEP."
   (let ((dependencies (cask-bundle-development-dependencies bundle)))
     (if deep
-        (cask--compute-dependencies dependencies 'cask--find-available-package)
+        (cask--compute-dependencies
+         dependencies
+         (lambda (name) (cask--find-package bundle name)))
       dependencies)))
 
 (defun cask--dependencies (bundle &optional deep)
@@ -557,7 +588,7 @@ is signaled."
       (cask-print "linked\n"))
     (when (epl-package-installed-p name)
       (cask-print (bold (black "already present")) "\n"))
-    (unless (or (epl-package-installed-p name) (cask-linked-p bundle name))
+    (when (cask--dependency-installable-p bundle dependency)
       (if (cask-dependency-fetcher dependency)
           (shut-up
             (let ((package-path (cask--checkout-and-package-dependency dependency)))
@@ -655,6 +686,20 @@ Return list of updated packages."
     :refresh t
     (epl-find-upgrades)))
 
+(defun cask--dependency-installable-p (bundle dependency)
+  "Return non-nil if DEPENDENCY is installable.
+
+An installable dependency is one which is not already present or
+locally linked with \"cask link\"."
+  (let ((name (cask-dependency-name dependency)))
+    (not (or (epl-package-installed-p name) (cask-linked-p bundle name)))))
+
+(defun cask--get-dependencies-to-install (bundle)
+  "Return all the dependencies which need to be installed."
+  (let ((dependencies (cask--dependencies bundle 'deep)))
+    (-filter (lambda (dep) (cask--dependency-installable-p bundle dep))
+             dependencies)))
+
 (defun cask-install (bundle)
   "Install BUNDLE dependencies.
 
@@ -669,22 +714,31 @@ If a dependency failed to install, signal a
 `cask-failed-installation' error, whose data is a `(DEPENDENCY
 . ERR)', where DEPENDENCY is the `cask-dependency' which failed
 to install, and ERR is the original error data."
-  (let (missing-dependencies)
-    (cask-print (green "Loading package information... "))
-    (cask--with-environment bundle
-      :force t
-      :refresh t
-      (cask-print (green "done") "\n")
-      (cask-print (green "Package operations: %d installs, %d removals\n" (length (cask--dependencies bundle)) 0))
-      (-each-indexed (cask--dependencies bundle)
+  (cask-print (green "Loading package information... "))
+  (cask--with-environment bundle
+    :force t
+    :refresh t
+    (cask-print (green "done") "\n")
+    (cask-print (green "Package operations: %d installs, %d removals\n" (length (cask--dependencies bundle)) 0))
+    (let* ((to-install (cask--get-dependencies-to-install bundle))
+           (missing-dependencies
+            (-reject
+             (lambda (dep)
+               (or (not (cask--dependency-installable-p bundle dep))
+                   (--any-p (eq (cask-dependency-name dep)
+                                (cask-dependency-name it))
+                            to-install)))
+             (cask--dependencies bundle))))
+      (-each-indexed to-install
         (lambda (index dependency)
-          (condition-case err
-              (cask--install-dependency bundle dependency index)
-            (cask-missing-dependency
-             (push dependency missing-dependencies))
-            (error
-             (signal 'cask-failed-installation
-                     (list dependency err (shut-up-current-output)))))))
+          (shut-up
+            (condition-case err
+                (cask--install-dependency bundle dependency index)
+              (cask-missing-dependency
+               (push dependency missing-dependencies))
+              (error
+               (signal 'cask-failed-installation
+                       (list dependency err (shut-up-current-output))))))))
       (when missing-dependencies
         (signal 'cask-missing-dependencies (nreverse missing-dependencies))))))
 

--- a/cask.el
+++ b/cask.el
@@ -970,18 +970,19 @@ NAME-pkg.el or Cask file for the linking to be possible."
                           (cask-define-package-file link-bundle))
           (error "Link source %s does not have a Cask or %s-pkg.el file"
                  source name)))
-      (when (cask--initialized-p bundle)
-        (let ((link-path
-               (f-expand
-                (format "%s-%s"
-                        (cask-package-name link-bundle)
-                        (cask-package-version link-bundle))
-                (cask-elpa-path bundle))))
-          (when (f-exists? link-path)
-            (f-delete link-path 'force))
-          (-when-let (dependency-path (cask-dependency-path bundle name))
-            (f-delete dependency-path 'force))
-          (f-symlink source link-path))))))
+      (unless (cask--initialized-p bundle)
+        (make-directory (cask-elpa-path bundle) 'parents))
+      (let ((link-path
+             (f-expand
+              (format "%s-%s"
+                      (cask-package-name link-bundle)
+                      (cask-package-version link-bundle))
+              (cask-elpa-path bundle))))
+        (when (f-exists? link-path)
+          (f-delete link-path 'force))
+        (-when-let (dependency-path (cask-dependency-path bundle name))
+          (f-delete dependency-path 'force))
+        (f-symlink source link-path)))))
 
 (defun cask-link-delete (bundle name)
   "Delete BUNDLE link with NAME."

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -685,6 +685,20 @@
                 ("package-d" "0.0.1")
                 ("package-f" "0.0.1"))
     (cask-test/link bundle 'package-c "package-c-0.0.1")
+    (cask-install bundle)
+    (should (f-symlink? (cask-dependency-path bundle 'package-c)))))
+
+(ert-deftest cask-install-test/install-missing ()
+  "If a package is installed but its dependncies are not, install
+the missing dependencies."
+  (cask-test/with-bundle
+      '((source localhost)
+        (depends-on "package-c" "0.0.1"))
+    :packages '(("package-c" "0.0.1")
+                ("package-d" "0.0.1")
+                ("package-f" "0.0.1"))
+    (cask-install bundle)
+    (f-delete (cask-dependency-path bundle 'package-d) 'force)
     (cask-install bundle)))
 
 (ert-deftest cask-install-test/intact-load-path ()

--- a/test/cask-api-test.el
+++ b/test/cask-api-test.el
@@ -1078,6 +1078,16 @@
                         ("package-d-0.0.1" ,package-d-path))))
         (should (-same-items? actual expected))))))
 
+(ert-deftest cask-links-test/with-links-no-init ()
+  "Should initialize the elpa directory automatically."
+  (cask-test/with-bundle
+      '((source localhost)
+        (depends-on "package-c" "0.0.1"))
+    (let ((package-c-path (cask-test/link bundle 'package-c "package-c-0.0.1")))
+      (let ((actual (cask-links bundle))
+            (expected `(("package-c-0.0.1" ,package-c-path))))
+        (should (-same-items? actual expected))))))
+
 
 ;;;; cask-link
 


### PR DESCRIPTION
Fixes #442, Fixes #444 

@rejeep Any reason why we did not do this?

I want to `cask init`, then add a `(depends-on <local-project>)` then `cask link <local-project> path` and it should work.

Instead we guarded essentially that `cask install` was run beforehand.  I don't think it's necessary but I'm not sure.