### PR TITLE
Changing Org Source URL from HTTP to HTTPS

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -171,7 +171,8 @@ Slots:
     (melpa        . "https://melpa.org/packages/")
     (melpa-stable . "https://stable.melpa.org/packages/")
     (marmalade    . "https://marmalade-repo.org/packages/")
-    (org          . "http://orgmode.org/elpa/"))
+    (SC           . "http://joseito.republika.pl/sunrise-commander/")
+    (org          . "https://orgmode.org/elpa/"))
   "Mapping of source name and url.")
 
 (defconst cask-filename "Cask"


### PR DESCRIPTION
Since the Org source is widely used by the community, we want to make sure that no packages from this source are tampered with.

The Org source supports https: https://orgmode.org/elpa/, and this is the URL that we should all be using instead of the non-https URL just for extra security.

Here is a good article on this topic as a reference:
https://glyph.twistedmatrix.com/2015/11/editor-malware.html