### PR TITLE
Indicate unavailable packages in install log

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -566,6 +566,7 @@ is signaled."
               (cask-print "downloading\e[F\n")
               (shut-up (epl-package-install package)))
           (unless (epl-built-in-p name)
+            (cask-print (bold (red "not available")) "\n")
             (signal 'cask-missing-dependency (list dependency)))))
       (cask-print
        (format "\e[K  - Installing [%2d/%d]" (1+ index) (length (cask--dependencies bundle)))


### PR DESCRIPTION
When a package is anavailable the log used to look like this:

Loading package information... done
Package operations: 5 installs, 0 removals
  - Installing [ 1/5] mmm-mode (0.5.4)...   - Installing [ 2/5] cl-lib (0.5)... already present
  - Installing [ 3/5] emacs (24.3)... already present

Now it looks like this:

Loading package information... done
Package operations: 5 installs, 0 removals
  - Installing [ 1/5] mmm-mode (0.5.4)... not available
  - Installing [ 2/5] cl-lib (0.5)... already present
  - Installing [ 3/5] emacs (24.3)... already present