### PR TITLE
Don't use hard-coded (insecure) temp file paths.

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -96,12 +96,9 @@ The items in the list are on the form (package version)."
   "Run BODY in a sandboxed environment."
   `(f-with-sandbox (list cask-test/sandbox-path
                          cask-test/cvs-repo-path
-                         cask-tmp-path)
+                         temporary-file-directory)
      (unwind-protect
-         (let* ((default-directory cask-test/sandbox-path)
-                (cask-tmp-path (f-expand "tmp" cask-test/sandbox-path))
-                (cask-tmp-checkout-path (f-expand "checkout" cask-tmp-path))
-                (cask-tmp-packages-path (f-expand "packages" cask-tmp-path)))
+         (let* ((default-directory cask-test/sandbox-path))
            (when (f-dir? cask-test/sandbox-path)
              (f-delete cask-test/sandbox-path 'force))
            (f-mkdir cask-test/sandbox-path)


### PR DESCRIPTION
Use secure temp file functions instead and also ensure the removal of temporary files
after package installation.

Fixes symlink attacks like:
```
ln -s  /home/juergen/tmp/ /tmp/cask/checkout
```


This commit also extends the existing cask-checkout-and-package-dependency function  to install the  built package so that the temp path of the temporary file path is not used across function boundaries and easy deletion is possible. 
