### PR TITLE
Remove stray shutup expression

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -684,7 +684,7 @@ to install, and ERR is the original error data."
              (push dependency missing-dependencies))
             (error
              (signal 'cask-failed-installation
-                     (list dependency err (shut-up-current-output)))))))
+                     (list dependency err))))))
       (when missing-dependencies
         (signal 'cask-missing-dependencies (nreverse missing-dependencies))))))
 


### PR DESCRIPTION
The shutup macro was removed in
4e91656e4e0ac92a7d43e83ac113a76c4347bc10 but the use of
shut-up-current-output was left although it's not valid outside of the
macro.