### PR TITLE
Make Cask work in Windows, on Azure Pipelines

### DIFF
--- a/bin/cask.ps1
+++ b/bin/cask.ps1
@@ -1,0 +1,36 @@
+function Exec-Cask {
+    emacs -Q --batch --script "$Env:UserProfile\.cask\cask-cli.el" -- @args
+}
+
+function Exec-Command($cmd) {
+    $emacsLoadPath = $Env:EMACSLOADPATH
+    $path = $Env:Path
+    try {
+        $Env:EMACSLOADPATH = "$(Exec-Cask load-path)"
+        $Env:Path = "$(Exec-Cask path)"
+        & $cmd @args
+        $script:exitStatus = $?
+   } finally {
+        $Env:EMACSLOADPATH = $emacsLoadPath
+        $Env:Path = $path
+    }
+}
+
+$exitStatus = $true
+$caskCmd = $args[0]
+
+# For behavior when accessing nonexistent indices, see:
+# https://docs.microsoft.com/en-us/powershell/scripting/learn/deep-dives/everything-about-arrays#off-by-one-errors
+
+if ($caskCmd -eq "emacs") {
+    $rest = $args[1..$args.Length]
+    Exec-Command $args[0] @rest
+} elseif ($caskCmd -eq "exec") {
+    $rest = $args[2..$args.Length]
+    Exec-Command $args[1] @rest
+} else {
+    Exec-Cask $args
+}
+
+# Return $? of $true for nonzero [int] or $false
+if (-not $exitStatus) {throw "Bad exit"}

--- a/cask-cli.el
+++ b/cask-cli.el
@@ -363,6 +363,17 @@ Commands:
   "Be verbose and show debug output."
   (setq shut-up-ignore t))
 
+;; On macOS at least, `error' and `signal' can be traced, which is very useful.
+(defun cask-cli/trace (&rest prefixes)
+  "Trace functions whose name starts with one of PREFIXES.
+If PREFIXES are not specified, 'cask-' functions will be traced."
+  (require 'cask-trace (expand-file-name "cask-trace" cask-directory))
+  (cask-trace-print-entry t)
+  (cask-trace-print-exit t)
+  (if prefixes
+      (mapc #'cask-trace-prefix prefixes)
+    (cask-trace-prefix "cask-")))
+
 (defun cask-cli/silent ()
   "Be silent and do not print anything."
   (setq cask-cli--silent t))
@@ -411,6 +422,7 @@ Commands:
  (option "--debug" cask-cli/debug)
  (option "--path <path>" cask-cli/set-path)
  (option "--verbose" cask-cli/verbose)
+ (option "--trace [*]" cask-cli/trace)
  (option "--silent" cask-cli/silent))
 
 (provide 'cask-cli)

--- a/cask-trace.el
+++ b/cask-trace.el
@@ -1,0 +1,64 @@
+;;; cask-trace.el --- Cask: Tracing function calls  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019 Johan Andersson
+
+;; Author: Tuấn-Anh Nguyễn <ubolonton@gmail.com>
+;; Maintainer: Johan Andersson <johan.rejeep@gmail.com>
+;; URL: http://github.com/cask/cask
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Cask's tracing support, for troubleshooting non-interactive environments.
+
+;;; Code:
+
+(require 'trace)
+(require 'nadvice)
+(require 's)
+
+(defun cask-trace-print-message (f &rest args)
+  (let ((msg (apply f args)))
+    (message "[trace] %s" (s-trim-right msg))
+    msg))
+
+(defun cask-trace-print-entry (enabled)
+  (if enabled
+      (advice-add 'trace-entry-message :around #'cask-trace-print-message)
+    (advice-remove 'trace-entry-message #'cask-trace-print-message)))
+
+(defun cask-trace-print-exit (enabled)
+  (if enabled
+      (advice-add 'trace-exit-message :around #'cask-trace-print-message)
+    (advice-remove 'trace-exit-message #'cask-trace-print-message)))
+
+(defun cask-trace--map-prefix (prefix function)
+  (mapatoms
+   (lambda (s)
+     (when (and (string-prefix-p prefix (symbol-name s))
+                (functionp s)
+                (not (eq s #'cask-trace-print-message)))
+       (funcall function s)))))
+
+(defun cask-trace-prefix (prefix)
+  (cask-trace--map-prefix prefix #'trace-function))
+
+(defun cask-untrace-prefix (prefix)
+  (cask-trace--map-prefix prefix #'untrace-function))
+
+(provide 'cask-trace)
+;;; cask-trace.el ends here

--- a/cask.el
+++ b/cask.el
@@ -1019,7 +1019,10 @@ a directory specified by `cask-dist-path' in the BUNDLE path."
                   :files patterns
                   :dir path))
             (package-build-working-dir path)
-            (package-build-archive-dir target-dir))
+            (package-build-archive-dir target-dir)
+            ;; This assumes only package files are written. For these files
+            ;; there's practically no reason to use any other coding.
+            (buffer-file-coding-system 'utf-8-unix))
         (package-build--package rcp version)))))
 
 (provide 'cask)

--- a/test/cask.Tests.ps1
+++ b/test/cask.Tests.ps1
@@ -1,0 +1,87 @@
+﻿$here = Join-Path (Get-Item $MyInvocation.MyCommand.Path).Directory.Parent.FullName "bin"
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+
+. "$here\$sut"
+
+# These tests need Pester, the popular Powershell testing framework
+# From the project root, run: Invoke-Pester -EnableExit .\test\
+# This will create a top-level .cask dir for the whole run and abandon it on exit
+# TODO: environment modification and restoration
+# TODO: Exec-Cask
+
+Describe "Exec-Command Unit" {
+    function Foo {}
+    function emacs {}
+    Context "With fake receivers" {
+        Get-Command emacs | Select-Object -ExpandProperty CommandType | Should Be "Function"
+        Mock Foo {return [psCustomObject]@{args = $args}}
+        Mock emacs {return [psCustomObject]@{args = $args}}
+        It "sees two args" {
+            $result = cask exec Foo one two
+            $result.args[0] | Should Be "one"
+            $result.args[-1] | Should Be "two"
+            $result.args.Count | Should Be 2
+        }
+        Assert-MockCalled Foo -Times 1
+        It "sees two args emacs" {
+            $result = cask emacs one two
+            $result.args[0] | Should Be "one"
+            $result.args[-1] | Should Be "two"
+            $result.args.Count | Should Be 2
+        }
+        Assert-MockCalled emacs -Times 1
+        It "sees one arg" {
+            $result = cask exec foo one
+            $result.args[0] | Should Be "one"
+            $result.args[-1] | Should Be "one"
+            $result.args[1] | Should Be $null
+            $result.args.Count | Should Be 1
+        }
+        Assert-MockCalled Foo -Times 2
+        It "sees one arg emacs" {
+            $result = cask emacs one
+            $result.args[0] | Should Be "one"
+            $result.args[-1] | Should Be "one"
+            $result.args[1] | Should Be $null
+            $result.args.Count | Should Be 1
+        }
+        Assert-MockCalled emacs -Times 2
+        It "sees no args" {
+            $result = cask exec foo
+            $result.args[0] | Should Be $null
+            $result.args.Count | Should Be 0
+        }
+        Assert-MockCalled Foo -Times 3
+        It "sees no args emacs" {
+            $result = cask emacs
+            $result.args[0] | Should Be $null
+            $result.args.Count | Should Be 0
+        }
+        Assert-MockCalled emacs -Times 3
+    }
+}
+
+Describe "Exec-Command Functional" {
+    # Sanity first
+    Get-Command emacs | Select-Object -ExpandProperty CommandType | Should Be "Application"
+    Context "Exit status exported to invoker" {
+        It "exits zero" {
+            cask exec emacs -Q --batch --eval '(kill-emacs 0)'
+            $? | Should Be $true
+        }
+        It "exits nonzero" {
+            { cask exec emacs -Q --batch --eval '(kill-emacs 1)' } | Should Throw
+        }
+    }
+    Context "Params passed to subproc" {
+        It "prints args with exec" {
+            $result = cask exec emacs -Q --batch --eval '(princ command-line-args)'
+            $result | Should BeLike "(*\bin\emacs.exe --eval (princ command-line-args))"
+        }
+        It "prints args without exec" {
+            $result = cask emacs -Q --batch --eval '(princ command-line-args)'
+            $result | Should BeLike "(*\bin\emacs.exe --eval (princ command-line-args))"
+        }
+    }
+}
+


### PR DESCRIPTION
- Add `--trace` option. This is very useful for non-interactive debugging (e.g. on hosted CI environments).
- Add a PowerShell script `cask.ps1` to call Emacs directly, without going through Python at all. This is related to #285 and #449.
- Explicitly specify `prefer-utf-8` coding when building the package, to avoid `Select coding system` prompt (similar to, but not the same as #341). This is more of an issue with [package-build](https://github.com/melpa/package-build) though (when writing the entry file).

I've been using this on my Windows machine, and on Azure Pipelines (e.g. [this build](https://dev.azure.com/ubolonton/emacs-tree-sitter/_build/results?buildId=224), using [this script](https://github.com/ubolonton/emacs-tree-sitter/blob/master/bin/package.ps1)).