### PR TITLE
Add ~/.cask to git command

### DIFF
--- a/doc/guide/installation.rst
+++ b/doc/guide/installation.rst
@@ -28,7 +28,7 @@ You can also clone the repository explicitly:
 
 .. code-block:: console
 
-   $ git clone https://github.com/cask/cask.git
+   $ git clone https://github.com/cask/cask.git ~/.cask
 
 To upgrade a manual installation, use:
 


### PR DESCRIPTION
Added `~/.cask` to the end of the git command so that the subsequent instructions for modifying the PATH environment also works for git cloning.