### PR TITLE
Avoid twice call to ‘package-initialize’ in emacs 27/28

### DIFF
--- a/cask-bootstrap.el
+++ b/cask-bootstrap.el
@@ -53,7 +53,7 @@
             package-alist
             package-archive-contents
             (package-user-dir cask-bootstrap-dir))
-        (package-initialize)
+        (unless package--initialized (package-initialize))
         (condition-case nil
             (mapc 'require cask-bootstrap-packages)
           (error


### PR DESCRIPTION
In emacs 27/28, the function `package-initialize` will be called by emacs automatically.