### PR TITLE
Revert "Avoid twice call to ‘package-initialize’ in emacs 27/28"

### DIFF
--- a/cask-bootstrap.el
+++ b/cask-bootstrap.el
@@ -53,7 +53,7 @@
             package-alist
             package-archive-contents
             (package-user-dir cask-bootstrap-dir))
-        (unless package--initialized (package-initialize))
+        (package-initialize)
         (condition-case nil
             (mapc 'require cask-bootstrap-packages)
           (error


### PR DESCRIPTION
This reverts commit ef05bfe16b7555916baa73dd15d8ceda4039232d in #483.

This commit comes from discussion at #484.