### PR TITLE
Silence ‘package-initialize’ warning on startup

### DIFF
--- a/cask-bootstrap.el
+++ b/cask-bootstrap.el
@@ -60,6 +60,8 @@
             package-alist
             package-archive-contents
             (package-user-dir cask-bootstrap-dir))
+        (when (not (version< emacs-version "27"))
+            (setq package--initialized nil))
         (package-initialize)
         (mapc
          (lambda (package)


### PR DESCRIPTION
### Issue
The `package-initialize` call in `cask-bootstrap.el` is necessary for Cask to function properly, and since the introduction of macs 27, a warning has been thrown whenever `package-initialize` is called.

```
Warning (package): Unnecessary call to ‘package-initialize’ in init file [2 times]
```

### Proposed Solution
For versions 27+, set `package--initialized` to nil immediately before `package-initialize` is called in `cask-bootstrap.el`, to silence this warning. 

### Effects
This only short circuits following in `package-initialize`. `package--initialized` is set to `'t` before the end of `package-initialize` and there are no other conditional checks that reference it before that point (including in called functions).

``` elisp
  (when (and package--initialized (not after-init-time))
    (lwarn '(package reinitialization) :warning
           "Unnecessary call to `package-initialize' in init file"))

```