### PR TITLE
Fix environment variable values as well.

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -69,7 +69,7 @@ class EnvbShim():
 
     def __setitem__(self, key, value):
         key = self._fix_key(key)
-        self.environ[key] = value
+        self.environ[key] = self._fix_key(value)
 
     def get(self, key, default=None):
         key = self._fix_key(key)


### PR DESCRIPTION
Fixes issue with environment variables in Windows not supporting bytes
objects for variable keys or values.  An error will occur when running
'cask emacs', this corrects that problem.