### PR TITLE
Ensure CI is run when pushing to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,16 +2,9 @@ name: CI
 
 on:
   pull_request:
-    paths-ignore:
-    - '**.md'
-    - '**.rst'
   push:
-    paths-ignore:
-    - '**.md'
-    - '**.rst'
-    branches-ignore:
+    branches:
     - 'master'
-    - 'main'
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #539.

I excluded `paths-ignore`, because I think that filter has little impact, because you don't update the documentation as frequently as the code. If you still want them, you could change it as follows, because README is written in Org:

```yaml
    paths-ignore:
    - '**.md'
    - '**.org'
    - '**.rst'
```