### PR TITLE
Add NonGNU ELPA

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -183,6 +183,7 @@ Slots:
     (melpa        . "https://melpa.org/packages/")
     (melpa-stable . "https://stable.melpa.org/packages/")
     (marmalade    . "https://marmalade-repo.org/packages/")
+    (nongnu       . "https://elpa.nongnu.org/nongnu/")
     (org          . "https://orgmode.org/elpa/"))
   "Mapping of source name and url.")
 


### PR DESCRIPTION
[NonGNU ELPA](https://elpa.nongnu.org/) is a new package archive managed by Emacs maintainers that [doesn't require copyright assignment](https://git.savannah.gnu.org/cgit/emacs/nongnu.git/plain/README.org), included by default in Emacs 28.

The Org ELPA is now deprecated in favor of NonGNU:

> Org 9.5 will be the last release to be distributed on Org ELPA.  After
9.5, we won't use Org ELPA for new releases.  Past releases will still
be available, though maybe not indefinitely.
>
> The Org package will continue to be available through GNU ELPA (from
https://elpa.gnu.org/packages/) and a new Org-Contrib package will be
available from https://elpa.nongnu.org/nongnu/.
>
> --- https://list.orgmode.org/87blb3epey.fsf@gnu.org/