### PR TITLE
Fix shebang

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env -S bash -eu
 
 # Copyright (C) 2012, 2013, 2014 Johan Andersson
 # Copyright (C) 2013-2014, 2016 Sebastian Wiesner


### PR DESCRIPTION
The fix from #14 got lost when `bin/cask` was first translated to Python and then translated back in d1ee01ba. This puts it back so that Cask works with Nix and other platforms that don't have `bash` even symlinked in `/bin`.