### PR TITLE
Detect functionality, not OS

### DIFF
--- a/bin/cask
+++ b/bin/cask
@@ -38,12 +38,8 @@ case $subcommand in
 		;;
 	*)
 		WHICH=${WHICH:-which}
-		READLINK=$($WHICH readlink || true)
-		if [ "$(uname || true)" == "Darwin" ] ; then
-			READLINK=
-		fi
-		READLINK=${READLINK:-$($WHICH greadlink || true)}
-		if [ ! -z "$READLINK" ] ; then
+		READLINK=$($WHICH readlink || $WHICH greadlink)
+		if [ -n "$READLINK" ] && eval "$READLINK" -f "$CASK" &>/dev/null; then
 			SRCDIR__=$($READLINK -f "$CASK")
 		else
 			SRCDIR__=$(python -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$CASK")


### PR DESCRIPTION
`readlink -f` works on macOS 12, this PR makes Python unnecessary for those systems.