### PR TITLE
Add implementation for package-build--get-timestamp

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -175,6 +175,8 @@ Slots:
   (oref rcp dir))
 
 (cl-defmethod package-build--get-commit ((_rcp package-directory-recipe)))
+(cl-defmethod package-build--get-timestamp ((_rcp package-directory-recipe) _rev)
+  (time-convert (current-time) 'integer))
 
 (defvar cask-source-mapping
   `((gnu          . ,(concat (if (< emacs-major-version 27) "http" "https")


### PR DESCRIPTION
Upstream package-build added this new method which results in an error
when running cask since it's not implemented for package-directory-recipe.

See commit https://github.com/melpa/package-build/commit/f032c806169b0fabbcac1eb44a4f1ae00674bfa8

The timestamp is used for reproducible builds based on commit
timestamp it seems from the upstream code. This is probably not very
useful for cask so just provide the current time here.