### PR TITLE
Support older emacsen in package-build--get-timestamp

### DIFF
--- a/cask.el
+++ b/cask.el
@@ -176,7 +176,8 @@ Slots:
 
 (cl-defmethod package-build--get-commit ((_rcp package-directory-recipe)))
 (cl-defmethod package-build--get-timestamp ((_rcp package-directory-recipe) _rev)
-  (time-convert (current-time) 'integer))
+  (let ((now (current-time)))
+    (logior (lsh (car now) 16) (cadr now))))
 
 (defvar cask-source-mapping
   `((gnu          . ,(concat (if (< emacs-major-version 27) "http" "https")


### PR DESCRIPTION
Implement the conversion from lisp timestamp to integer manually.
The original patch for this method worked well for emacs 27 and
greater. However time-convert was introduced in emacs 27 so doesn't
work in older versions.