### PR TITLE
Fix bootstrapping using package-build-legacy

### DIFF
--- a/package-build/package-build-legacy.el
+++ b/package-build/package-build-legacy.el
@@ -1045,7 +1045,7 @@ This is a copy of `lm-homepage', which first appeared in Emacs 24.4."
 
 ;;; _
 
-(provide 'package-build)
+(provide 'package-build-legacy)
 
 ;; For the time being just require all libraries that contain code
 ;; that was previously located in this library.


### PR DESCRIPTION
Bootstrapping on Emacs 24.5.1 fails with the following message:

```
package-build/package-build-legacy.el: `object-class-fast' is an obsolete alias (as of 24.4); use `eieio--object-class' instead.
Required feature `package-build-legacy' was not provided
```

How to reproduce:

```
# Assuming the current directory is the source directory of Cask
docker \
    run \
    -it \
    --rm \
    --volume=$(pwd):/cask \
    --user $(id -u):$(id -g) \
    --env=HOME=/tmp \
    --workdir=/cask \
    silex/emacs:24 \
    /cask/bin/cask install
```
