### PR TITLE
Fix Makefile compatibility with recent GNU Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export CASK ?= bin/cask
 export EMACS ?= emacs
 export CASK_DIR := $(shell $(CASK) package-directory)
-SHELL := $(shell which bash)
+SHELL := $(shell command -v bash 2>/dev/null)
 SERVANT ?= servant
 SPHINX-BUILD = sphinx-build
 SPHINXFLAGS =
@@ -179,7 +179,7 @@ install: install-elisp
 	  false ; \
 	fi
 	$(eval TARGET = \
-	  $(shell if 1>/dev/null which systemd-path ; then \
+	  $(shell if 1>/dev/null command -v systemd-path ; then \
 	            echo "$$(systemd-path user-binaries)/cask" ; \
 	          elif [ ! -z "$(XDG_DATA_HOME)" ] ; then \
 	            echo "$(XDG_DATA_HOME)/../bin/cask" ; \

--- a/README.makefile
+++ b/README.makefile
@@ -1,4 +1,4 @@
-export EMACS ?= $(shell which emacs)
+export EMACS ?= $(shell command -v emacs 2>/dev/null)
 CASK_DIR := $(shell cask package-directory)
 
 $(CASK_DIR): Cask

--- a/README.org
+++ b/README.org
@@ -46,7 +46,7 @@ longer recommend/ ~cask exec ert-runner~ /nor/ ~cask exec ecukes~ /./
 Egregious boilerplate follows:
 
 #+begin_src makefile :tangle README.makefile
-export EMACS ?= $(shell which emacs)
+export EMACS ?= $(shell command -v emacs 2>/dev/null)
 CASK_DIR := $(shell cask package-directory)
 
 $(CASK_DIR): Cask


### PR DESCRIPTION
GNU Make will directly invoke simple commands[1], which causes the following error when installing Cask:

    make: which: No such file or directory
    bin/cask install
    make: -c: No such file or directory
    make: *** [Makefile:47: /home/wilfred/src/cask/.cask/29.1/elpa] Error 127

This is because `which` is a shell built-in, and there's no guarantee that there's a `which` binary available (e.g. my Arch Linux system doesn't have one).

Use `command -v`, which is more portable, and use shell redirection so Make never attempts to directly invoke it.

[1] https://stackoverflow.com/questions/17547625/how-to-use-shell-builtin-function-from-a-makefile/17550243#17550243