### PR TITLE
Add DESTDIR option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,9 @@ install: install-elisp
 	  false ; \
 	fi
 	$(eval TARGET = \
-	  $(shell if 1>/dev/null command -v systemd-path ; then \
+	  $(shell if [ ! -z "$(DESTDIR)" ] ; then \
+	            echo "$(DESTDIR)/cask" ; \
+	          elif 1>/dev/null command -v systemd-path ; then \
 	            echo "$$(systemd-path user-binaries)/cask" ; \
 	          elif [ ! -z "$(XDG_DATA_HOME)" ] ; then \
 	            echo "$(XDG_DATA_HOME)/../bin/cask" ; \


### PR DESCRIPTION
This makes it possible to specify a directory to install into, avoiding the kind of frustration evident in https://github.com/cask/cask/issues/597.