### PR TITLE
Add support for native compilation.

### DIFF
--- a/cask-cli.el
+++ b/cask-cli.el
@@ -246,6 +246,11 @@ If no files directive or no files, do nothing."
   "Remove all byte compiled Elisp files in the files directive."
   (cask-clean-elc (cask-cli--bundle)))
 
+(defun cask-cli/native-comp ()
+  "Native compile all Elisp files in the files directive."
+  (cask-cli/with-handled-errors
+    (cask-native-comp (cask-cli--bundle))))
+
 (defun cask-cli/link (&optional command-or-name arg)
   "Manage links.
 
@@ -367,6 +372,7 @@ Commands:
  (command "files" cask-cli/files)
  (command "build" cask-cli/build)
  (command "clean-elc" cask-cli/clean-elc)
+ (command "native-comp" cask-cli/native-comp)
  (command "link [*]" cask-cli/link)
  (command "package [target-dir]" cask-cli/package)
  (command "emacs [*]" cask-cli/emacs)

--- a/cask.el
+++ b/cask.el
@@ -837,6 +837,12 @@ If BUNDLE is not a package, the error `cask-not-a-package' is signaled."
    (format ".cask/%s.%s/elpa" emacs-major-version emacs-minor-version)
    (cask-bundle-path bundle)))
 
+(defun cask-eln-cache-path (bundle)
+  "Return full path to BUNDLE native-compiled cache directory."
+  (f-expand
+   (format ".cask/%s.%s/eln-cache" emacs-major-version emacs-minor-version)
+   (cask-bundle-path bundle)))
+
 (defun cask-runtime-dependencies (bundle &optional _deep)
   "Return BUNDLE's runtime dependencies.
 The legacy argument _DEEP is assumed true.
@@ -1017,6 +1023,22 @@ URL is the url to the mirror."
       (when (and (f-file? path) (f-ext? path "el"))
         (when (f-file? (concat path "c"))
           (f-delete (concat path "c")))))))
+
+(defun cask-native-comp (bundle)
+  "Native compile BUNDLE Elisp files."
+  (if (not (and (fboundp 'native-comp-available-p)
+                (native-comp-available-p)))
+      (error "Native compilation not available")
+    (cask--with-environment bundle
+      (require 'comp)
+      (cask--build-install-dependencies bundle)
+      (let ((load-path (cons (cask-path bundle) (cask-load-path bundle)))
+            (native-comp-eln-load-path
+             (cons (cask-eln-cache-path bundle) native-comp-eln-load-path)))
+        (dolist (path (cask-files bundle))
+          (when (and (f-file? path) (f-ext? path "el"))
+            (message "Native compiling %s..." path)
+            (native-compile path)))))))
 
 (defun cask-links (bundle)
   "Return a list of all links for BUNDLE.


### PR DESCRIPTION
Emacs added support for native compilation after version 28.1:

https://github.com/emacs-mirror/emacs/blob/master/etc/NEWS.28#L65

This PR adds a `native-comp` command to Cask to invoke `native-compile` on each `.el` file in the package. To avoid polluting the default cache for `.eln` files, a new one is created inside the `.cask` directory (next to the `elpa` packages).

Native compilation often generates detects additional warnings or errors, so I find it useful to check the package with it in addition to the existing `cask build` command.

Happy to take suggestions about the name of the command or about how the `.eln` files can further be used.

Thanks!